### PR TITLE
feat: add multi-architecture Docker build support

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -51,3 +51,5 @@ jobs:
         labels: ${{ steps.meta.outputs.labels }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
+        provenance: false
+        sbom: false

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,53 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log in to Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Extract metadata (tags, labels) for Docker
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+        tags: |
+          type=ref,event=branch
+          type=ref,event=pr
+          type=raw,value=latest,enable={{is_default_branch}}
+
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        platforms: linux/amd64,linux/arm64
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary

Add GitHub Actions workflow for building multi-architecture Docker images with clean manifests.

- Support both `linux/amd64` and `linux/arm64` platforms
- Publish to GitHub Container Registry (ghcr.io)  
- Enable build caching for faster builds
- **Clean multi-arch manifest**: No unknown/unknown artifacts

## Problem

The current Docker image (`andig/evopt:latest`) only supports ARM64 architecture, causing `ImagePullBackOff` errors on AMD64 Kubernetes clusters:

```
Failed to pull image "andig/evopt": rpc error: code = NotFound desc = failed to pull and unpack image "docker.io/andig/evopt:latest": no match for platform in manifest: not found
```

## Solution

This PR adds a GitHub Actions workflow that:

1. **Multi-architecture builds**: Builds images for both `linux/amd64` and `linux/arm64`
2. **GitHub Container Registry**: Publishes to `ghcr.io/jr42/evopt` (as demonstration)
3. **Automatic builds**: Triggers on push to main branch and pull requests
4. **Build caching**: Uses GitHub Actions cache for faster subsequent builds
5. **Clean manifests**: Disables provenance/SBOM to avoid unknown/unknown artifacts

## Clean Multi-Architecture Manifest

The resulting image has a clean multi-architecture manifest with only the target platforms:

```json
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 2076,
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json", 
         "size": 2075,
         "platform": {
            "architecture": "arm64",
            "os": "linux"
         }
      }
   ]
}
```

No more confusing `unknown/unknown` architecture entries!

## Testing

- ✅ GitHub Actions workflow builds successfully
- ✅ Clean multi-arch manifest with only amd64 and arm64
- ✅ Image successfully pulls and runs on AMD64 Kubernetes cluster
- ✅ Maintains compatibility with existing ARM64 deployments
- ✅ Available at `ghcr.io/jr42/evopt:latest` for testing

## Workflow Features

- **Automated**: Builds on push to main and pull requests
- **Cached builds**: Faster subsequent builds using GitHub Actions cache
- **Proper tagging**: Branch names, PR numbers, and `latest` for main
- **No secrets required**: Uses built-in `GITHUB_TOKEN`

## Integration Notes

If you prefer Docker Hub over GitHub Container Registry, the workflow can be easily adapted to publish to `docker.io/andig/evopt` instead by:
1. Changing `REGISTRY: ghcr.io` to `REGISTRY: docker.io`  
2. Adding Docker Hub credentials as repository secrets
3. Updating login configuration

🤖 Generated with [Claude Code](https://claude.ai/code)