### PR TITLE
Fix strategy incentive and unintended discharging to grid

### DIFF
--- a/optimizer.py
+++ b/optimizer.py
@@ -124,7 +124,7 @@ class Optimizer:
             else:
                 self.variables['z_c'][i] = None
 
-        # Binary variable to lock chrging against discharging
+        # Binary variable to lock charging against discharging
         self.variables['z_cd'] = {}
         for i, bat in enumerate(self.batteries):
             self.variables['z_cd'][i] = [


### PR DESCRIPTION
fixed:
- promoted s[i][t] instead of c[i][t] which looks right in many cases but creates weird results in others.
- effectless lock against discharging to grid
- charging against discharging not explicitely locked