### PR TITLE
Set indent style for python in editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -17,3 +17,7 @@ indent_size = 2
 [*.{js,html,yml,yaml,json,md,ts}]
 indent_style = space
 indent_size = 2
+
+[*.py]
+indent_style = space
+


### PR DESCRIPTION
When opening the project in an editor that reads `.editorconfig` editing python files will not work by default since new lines will use tabs instead of spaces. This PR changes the `indent_style` for .py files in the `.editorconfig`.