### PR TITLE
Use TemporaryDirectory for tmpDir with Cleanup

### DIFF
--- a/src/evopt/optimizer.py
+++ b/src/evopt/optimizer.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from tempfile import TemporaryDirectory
 from typing import Dict, List, Optional
 
 import numpy as np
@@ -469,7 +470,9 @@ class Optimizer:
             threads=self.settings.num_threads,
             timeLimit=self.settings.time_limit,
         )
-        self.problem.solve(solver)
+        with TemporaryDirectory() as tmpdir:
+            solver.tmpDir = tmpdir
+            self.problem.solve(solver)
 
         # Extract results
         status = pulp.LpStatus[self.problem.status]


### PR DESCRIPTION
Uses the context-manager version of TemporaryDirectory to more reliably cleanup temporary files in case of worker exit.