### PR TITLE
streamline GridConfig key naming: prc_p_imp_exc -> prc_p_exc_imp

### DIFF
--- a/client/client.gen.go
+++ b/client/client.gen.go
@@ -116,9 +116,9 @@ type GridConfig struct {
 	// PMaxImp Maximum grid import power in W
 	PMaxImp float32 `json:"p_max_imp,omitempty"`
 
-	// PrcPImpExc price per W to consider in case the import limit is exceeded.
+	// PrcPExcImp price per W to consider in case the import limit is exceeded.
 	// If not specified, the limit will be protected by a hard constraint.
-	PrcPImpExc float32 `json:"prc_p_imp_exc,omitempty"`
+	PrcPExcImp float32 `json:"prc_p_exc_imp,omitempty"`
 }
 
 // LimitViolationResult defines model for LimitViolationResult.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -176,7 +176,7 @@ components:
           type: number
           minimum: 0
           description: Maximum grid export power in W
-        prc_p_imp_exc:
+        prc_p_exc_imp:
           type: number
           minimum: 0
           description: |

--- a/src/evopt/app.py
+++ b/src/evopt/app.py
@@ -61,7 +61,7 @@ strategy_model = api.model('OptimizationStrategy', {
 grid_model = api.model('GridConfig', {
     'p_max_imp': fields.Float(required=False, description='Maximum grid import power in W'),
     'p_max_exp': fields.Float(required=False, description='Maximum grid export power in W'),
-    'prc_p_imp_exc': fields.Float(required=False, description='price per W to consider in case the import limit is exceeded. ')
+    'prc_p_exc_imp': fields.Float(required=False, description='price per W to consider in case the import limit is exceeded. ')
 })
 
 battery_config_model = api.model('BatteryConfig', {


### PR DESCRIPTION
merge should be safe as GridConfig isn't used yet in site_optimizer.go (except by me)