### PR TITLE
Don't report micro violations of grid limits

### DIFF
--- a/src/evopt/optimizer.py
+++ b/src/evopt/optimizer.py
@@ -499,13 +499,13 @@ class Optimizer:
         grid_imp_limit_violated = False
         e_grid_imp_overshoot = []
         if self.grid.p_max_imp is not None and not self.is_grid_demand_rate_active:
-            grid_imp_limit_violated = (np.max([pulp.value(var) for var in self.variables['e_imp_lim_exc']]) > 0)
+            grid_imp_limit_violated = (np.max([pulp.value(var) for var in self.variables['e_imp_lim_exc']]) > 0.1)
             e_grid_imp_overshoot = [pulp.value(var) for var in self.variables['e_imp_lim_exc']]
         # grid export limit
         grid_exp_limit_hit = False
         e_grid_exp_overshoot = []
         if self.grid.p_max_exp is not None:
-            grid_exp_limit_hit = (np.max([pulp.value(var) for var in self.variables['e_exp_lim_exc']]) > 0)
+            grid_exp_limit_hit = (np.max([pulp.value(var) for var in self.variables['e_exp_lim_exc']]) > 0.1)
             e_grid_exp_overshoot = [pulp.value(var) for var in self.variables['e_exp_lim_exc']]
 
         if status == 'Optimal':

--- a/src/evopt/optimizer.py
+++ b/src/evopt/optimizer.py
@@ -494,19 +494,24 @@ class Optimizer:
             for t in self.time_steps:
                 e_grid_import[t] += pulp.value(self.variables['e_imp_lim_exc'][t])
 
+       # snap near-zero solver noise to zero
+        eps = 1e-6
+
         # get limit violations
         # grid import limit
         grid_imp_limit_violated = False
         e_grid_imp_overshoot = []
         if self.grid.p_max_imp is not None:
-            grid_imp_limit_violated = (np.max([pulp.value(var) for var in self.variables['e_imp_lim_exc']]) > 0.1)
-            e_grid_imp_overshoot = [pulp.value(var) for var in self.variables['e_imp_lim_exc']]
+            e_grid_imp_overshoot = [max(0, pulp.value(var)) if pulp.value(var) > eps else 0
+                                    for var in self.variables['e_imp_lim_exc']]
+            grid_imp_limit_violated = max(e_grid_imp_overshoot) > 0
         # grid export limit
         grid_exp_limit_hit = False
         e_grid_exp_overshoot = []
         if self.grid.p_max_exp is not None:
-            grid_exp_limit_hit = (np.max([pulp.value(var) for var in self.variables['e_exp_lim_exc']]) > 0.1)
-            e_grid_exp_overshoot = [pulp.value(var) for var in self.variables['e_exp_lim_exc']]
+            e_grid_exp_overshoot = [max(0, pulp.value(var)) if pulp.value(var) > eps else 0
+                                    for var in self.variables['e_exp_lim_exc']]
+            grid_exp_limit_hit = max(e_grid_exp_overshoot) > 0
 
         if status == 'Optimal':
             result = {

--- a/src/evopt/optimizer.py
+++ b/src/evopt/optimizer.py
@@ -499,16 +499,20 @@ class Optimizer:
 
         # get limit violations
         # grid import limit
+        grid_imp_limit_violated = False
         e_grid_imp_overshoot = []
         if self.grid.p_max_imp is not None:
             e_grid_imp_overshoot = [max(0, pulp.value(var)) if pulp.value(var) > eps else 0
                                     for var in self.variables['e_imp_lim_exc']]
+            grid_imp_limit_violated = max(e_grid_imp_overshoot) > 0
         # grid export limit
+        grid_exp_limit_hit = False
         e_grid_exp_overshoot = []
         if self.grid.p_max_exp is not None:
             e_grid_exp_overshoot = [max(0, pulp.value(var)) if pulp.value(var) > eps else 0
                                     for var in self.variables['e_exp_lim_exc']]
-
+            grid_exp_limit_hit = max(e_grid_exp_overshoot) > 0
+            
         if status == 'Optimal':
             result = {
                 'status': status,

--- a/src/evopt/optimizer.py
+++ b/src/evopt/optimizer.py
@@ -499,7 +499,7 @@ class Optimizer:
         grid_imp_limit_violated = False
         e_grid_imp_overshoot = []
         if self.grid.p_max_imp is not None:
-            grid_imp_limit_violated = (np.max([pulp.value(var) for var in self.variables['e_imp_lim_exc']]) > 0)
+            grid_imp_limit_violated = (np.max([pulp.value(var) for var in self.variables['e_imp_lim_exc']]) > 0.1)
             e_grid_imp_overshoot = [pulp.value(var) for var in self.variables['e_imp_lim_exc']]
         # grid export limit
         grid_exp_limit_hit = False

--- a/src/evopt/optimizer.py
+++ b/src/evopt/optimizer.py
@@ -499,19 +499,15 @@ class Optimizer:
 
         # get limit violations
         # grid import limit
-        grid_imp_limit_violated = False
         e_grid_imp_overshoot = []
         if self.grid.p_max_imp is not None:
             e_grid_imp_overshoot = [max(0, pulp.value(var)) if pulp.value(var) > eps else 0
                                     for var in self.variables['e_imp_lim_exc']]
-            grid_imp_limit_violated = max(e_grid_imp_overshoot) > 0
         # grid export limit
-        grid_exp_limit_hit = False
         e_grid_exp_overshoot = []
         if self.grid.p_max_exp is not None:
             e_grid_exp_overshoot = [max(0, pulp.value(var)) if pulp.value(var) > eps else 0
                                     for var in self.variables['e_exp_lim_exc']]
-            grid_exp_limit_hit = max(e_grid_exp_overshoot) > 0
 
         if status == 'Optimal':
             result = {


### PR DESCRIPTION
Just a suggestion and any other value than 0.1 might be better.
but currently resonses appear like 
"grid_import_overshoot": [0, 0, 0, 1.3600118e-10, 0, 0, 1.3600118e-10,...
