### PR TITLE
feat: let attenuate_grid_peaks withhold charging (#71)

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -158,7 +158,9 @@ components:
             Sets a strategy for charging in situations where choices are cost neutral.
             - none (default): no strategy set 
             - charge_before_export: charge batteries before exporting to grid
-            - attenuate_grid_peaks: charge at times with high solar yield to reduce the grid load
+            - attenuate_grid_peaks: charge at times with high solar yield to reduce the grid load.
+              For batteries with `withhold_charge: true` the strategy may also actively withhold charging
+              below the solar peak to keep capacity available for the peak, not just defer it.
         discharging_strategy:
           type: string
           enum: [none, discharge_before_import]
@@ -269,6 +271,14 @@ components:
           maximum: 2
           default: 0
           description: Charging and discharging priority 0..2 compared to other batteries. 2 = highest priority.
+        withhold_charge:
+          type: boolean
+          default: false
+          description: |
+            Signals that the battery hardware can actively pause charging (e.g. hold/stop charge).
+            - True: under the attenuate_grid_peaks strategy the optimizer may withhold charging below the
+              solar peak to keep capacity available for peak shaving, accepting cost-neutral surplus export.
+            - False: (default) the strategy may only re-time (defer) charging, never forgo it.
 
     TimeSeries:
       type: object

--- a/src/optimizer/app.py
+++ b/src/optimizer/app.py
@@ -77,7 +77,11 @@ battery_config_model = api.model('BatteryConfig', {
     'c_max': fields.Float(required=True, description='Maximum charge power (W)'),
     'd_max': fields.Float(required=True, description='Maximum discharge power (W)'),
     'p_a': fields.Float(required=True, description='Monetary value per Wh at end of the optimization horizon'),
-    'c_priority': fields.Integer(required=False, description='Charging and discharging priority compared to other batteries. 2 = highest priority.')
+    'c_priority': fields.Integer(required=False, description='Charging and discharging priority compared to other batteries. 2 = highest priority.'),
+    'withhold_charge': fields.Boolean(
+        required=False,
+        description='Battery can actively pause charging; lets the attenuate_grid_peaks strategy '
+                    'withhold (not just defer) charging below the solar peak to reserve capacity.')
 })
 
 time_series_model = api.model('TimeSeries', {
@@ -168,6 +172,7 @@ class OptimizeCharging(Resource):
                     d_max=bat_data['d_max'],
                     p_a=bat_data['p_a'],
                     c_priority=bat_data.get('c_priority', 0),
+                    withhold_charge=bat_data.get('withhold_charge', False),
                 ))
 
             # Parse time series data

--- a/src/optimizer/optimizer.py
+++ b/src/optimizer/optimizer.py
@@ -36,6 +36,7 @@ class BatteryConfig:
     p_demand: Optional[List[float]] = None  # Minimum charge demand (Wh)
     s_goal: Optional[List[float]] = None  # Goal state of charge (Wh)
     c_priority: int = 0
+    withhold_charge: bool = False  # battery can actively pause charging (enables withholding under attenuate_grid_peaks)
 
 
 @dataclass
@@ -80,6 +81,9 @@ class Optimizer:
         # Compute scaling for strategy control parameters
         self.min_import_price = np.min(self.time_series.p_N)
         self.max_import_price = np.max(self.time_series.p_N)
+
+        # peak solar production over the horizon, used to scale the attenuate_grid_peaks strategy
+        self.max_solar = np.max(self.time_series.ft) if len(self.time_series.ft) else 0.0
 
         # scaling base for penalty parameters. Make sure goal_penalty is always positive.
         penalty_base = np.max([self.max_import_price, 0.1e-3])
@@ -309,7 +313,13 @@ class Optimizer:
         if self.strategy.charging_strategy == 'attenuate_grid_peaks':
             for i, bat in enumerate(self.batteries):
                 for t in self.time_steps:
+                    # defer charging towards high solar production (attenuates the export peak)
                     objective += self.variables['c'][i][t] * self.time_series.ft[t] * self.min_import_price * 1e-6
+                    # if the battery hardware can pause charging, actively withhold charging below the
+                    # solar peak so capacity stays available to absorb the peak. Without this capability the
+                    # strategy may only re-time (defer) charging, not forgo it.
+                    if bat.withhold_charge:
+                        objective -= self.variables['c'][i][t] * (self.max_solar - self.time_series.ft[t]) * self.min_import_price * 1e-6
 
         # prefer discharging batteries completely before importing from grid
         if self.strategy.discharging_strategy == 'discharge_before_import':

--- a/tests/test_attenuate_grid_peaks.py
+++ b/tests/test_attenuate_grid_peaks.py
@@ -1,0 +1,78 @@
+import numpy as np
+
+from optimizer.optimizer import (
+    BatteryConfig,
+    GridConfig,
+    OptimizationStrategy,
+    Optimizer,
+    TimeSeriesData,
+)
+
+
+def _solve(withhold_charge: bool):
+    """
+    Cost-neutral scenario: storing energy is worth exactly the export price (p_a == p_E),
+    so the attenuate_grid_peaks strategy is the only term deciding *whether* and *when* the
+    battery absorbs surplus. Surplus is available in a small morning hump (t0, ft=100) and a
+    large midday peak (t2, ft=1000). The morning hump sits at t1 (not t0) so the first-step
+    SOC baseline used by the clean objective stays identical across both runs.
+    """
+    strategy = OptimizationStrategy(
+        charging_strategy='attenuate_grid_peaks',
+        discharging_strategy='none',
+    )
+    grid = GridConfig(p_max_imp=None, p_max_exp=None, prc_p_exc_imp=None)
+    battery = BatteryConfig(
+        charge_from_grid=False,
+        discharge_to_grid=False,
+        s_capacity=2000,
+        s_min=0,
+        s_max=2000,
+        s_initial=0,
+        c_min=0,
+        c_max=5000,
+        d_max=0,
+        p_a=0.1,
+        withhold_charge=withhold_charge,
+    )
+    time_series = TimeSeriesData(
+        dt=[3600, 3600, 3600, 3600],
+        gt=[0, 0, 0, 0],
+        ft=[0, 100, 1000, 0],
+        p_N=[0.3, 0.3, 0.3, 0.3],
+        p_E=[0.1, 0.1, 0.1, 0.1],
+    )
+
+    optimizer = Optimizer(strategy, grid, [battery], time_series, eta_c=1.0, eta_d=1.0)
+    return optimizer.solve()
+
+
+def test_defer_charges_all_available_surplus():
+    """Without the withhold capability the strategy only re-times charging and still stores
+    the low-solar morning surplus."""
+    result = _solve(withhold_charge=False)
+
+    assert result['status'] == 'Optimal'
+    charging = result['batteries'][0]['charging_power']
+    assert np.isclose(charging[1], 100, atol=1e-3), "morning surplus should be stored"
+    assert np.isclose(charging[2], 1000, atol=1e-3), "midday peak should be stored"
+
+
+def test_withhold_skips_low_solar_charging():
+    """With the withhold capability the strategy forgoes charging below the solar peak,
+    leaving capacity free and exporting the morning surplus instead."""
+    result = _solve(withhold_charge=True)
+
+    assert result['status'] == 'Optimal'
+    charging = result['batteries'][0]['charging_power']
+    assert np.isclose(charging[1], 0, atol=1e-3), "morning surplus should be withheld, not stored"
+    assert np.isclose(charging[2], 1000, atol=1e-3), "midday peak should still be stored"
+
+
+def test_withhold_is_cost_neutral():
+    """Withholding must not change the actual economic outcome; it only acts on cost-neutral
+    choices (the clean objective excludes strategy incentives)."""
+    defer = _solve(withhold_charge=False)
+    withhold = _solve(withhold_charge=True)
+
+    assert np.isclose(defer['objective_value'], withhold['objective_value'], rtol=1e-6, atol=1e-9)


### PR DESCRIPTION
closes #71

The `attenuate_grid_peaks` charging strategy could previously only re-time charging toward high-solar intervals, never forgo it. For feed-in peak shaving (Solarspitzengesetz) the battery should also be able to hold off charging early in the day, so feed-in spreads out and capacity stays free to absorb the midday peak that would otherwise be lost to the export cap. Whether the optimizer may plan this depends on the battery being able to pause charging (the counterpart to evcc-io/evcc#27906), so it is gated behind a new per-battery capability.

- New per-battery `withhold_charge` flag (default `false`), behavior unchanged when unset
- Under `attenuate_grid_peaks`, a `withhold_charge` battery gets a net-negative incentive on charging below the solar peak, so it may forgo charging and export cost-neutral surplus instead of filling early
- The incentive stays in the cost-neutral tie-breaker layer, so the economic optimum is unaffected
- Added tests covering the defer versus withhold behavior and cost-neutrality