### PR TITLE
fix: return JSON body for message-only 400 aborts

### DIFF
--- a/src/optimizer/app.py
+++ b/src/optimizer/app.py
@@ -45,6 +45,9 @@ def handle_validation_error(error):
         error.data['details'] = error.data['errors']
         del error.data['errors']
         return error.data, 400
+    elif error.data:
+        # plain api.abort(400, message) calls carry only a message
+        return error.data, 400
     else:
         raise error
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -34,3 +34,25 @@ def test_optimizer(test_case: pathlib.Path):
                              expected_objective_value,
                              rtol=1e-05, atol=1e-08, equal_nan=False), \
             f"objective value: {actual_objective_value}, expected was: {expected_objective_value}"
+
+
+def test_abort_returns_json_message():
+    # message-only api.abort(400, ...) must return a JSON body, not an empty response
+    client = app.test_client()
+    request = {
+        "batteries": [{
+            "s_min": 0, "s_max": 10000, "s_initial": 5000,
+            "c_min": 0, "c_max": 5000, "d_max": 5000, "p_a": 0.1,
+        }],
+        "time_series": {
+            "dt": [3600, 3600],
+            "gt": [1000, 1000],
+            "ft": [0, 0],
+            "p_N": [0.3, 0.3],
+            "p_E": [0.1],  # length mismatch triggers api.abort(400, message)
+        },
+    }
+    response = client.post("/optimize/charge-schedule", json=request)
+    assert response.status_code == 400
+    assert response.json is not None
+    assert "message" in response.json


### PR DESCRIPTION
## Bug

`api.abort(400, message)` calls (e.g. `"Invalid data format"`, `"All time series must have the same length"` on `/optimize/charge-schedule`) return a 400 with an **empty, non-JSON body** — clients never see the error message.

## Root cause

The custom `@api.errorhandler(BadRequest)` only returns a JSON body for schema-validation errors (payloads carrying an `errors` key, renamed to `details`). Message-only aborts fall into the `else: raise error` branch and render without a JSON body.

## Fix

Return `error.data` (i.e. `{"message": ...}`) for message-only aborts as well. Validation-error behavior is unchanged. Regression test included.

Found while adding the heating-parameters endpoint in #85 (which returns fit errors via `api.abort(400, str(e))`); raised separately since it affects existing endpoints on main independent of that PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)