### PR TITLE
perf: tighten indicator big-Ms to natural per-step bounds

### DIFF
--- a/src/optimizer/optimizer.py
+++ b/src/optimizer/optimizer.py
@@ -408,12 +408,22 @@ class Optimizer:
                              == e_grid_exp
                              + self.time_series.gt[t])
 
-        # Constraints (4)-(5): Grid flow direction
+        # Constraints (4)-(5): Grid flow direction. Export/import have natural
+        # per-step caps (export: solar plus discharge-to-grid capacity; import:
+        # demand plus grid-charge capacity) that tighten the LP relaxation vs
+        # the global big-M without excluding any integer point. When a grid
+        # limit is active, the opposite side's unbounded excess variable enters
+        # the energy balance, so only then fall back to the global big-M.
+        cap_d_exp = sum(b.d_max for b in self.batteries if b.discharge_to_grid)
+        cap_c_imp = sum(b.c_max for b in self.batteries if b.charge_from_grid)
         for t in self.time_steps:
+            dth = self.time_series.dt[t] / 3600.
+            m_exp = self.time_series.ft[t] + cap_d_exp * dth if self.grid.p_max_imp is None else self.M
+            m_imp = self.time_series.gt[t] + cap_c_imp * dth if self.grid.p_max_exp is None else self.M
             # Export constraint
-            self.problem += self.variables['e'][t] <= self.M * self.variables['y'][t]
+            self.problem += self.variables['e'][t] <= m_exp * self.variables['y'][t]
             # Import constraint
-            self.problem += self.variables['n'][t] <= self.M * (1 - self.variables['y'][t])
+            self.problem += self.variables['n'][t] <= m_imp * (1 - self.variables['y'][t])
 
         # limit regular grid import power
         if self.grid.p_max_imp is not None:
@@ -422,7 +432,8 @@ class Optimizer:
                 for t in self.time_steps:
                     self.problem += self.variables['n'][t] <= self.grid.p_max_imp * self.time_series.dt[t] / 3600
                     self.problem += (self.grid.p_max_imp * self.time_series.dt[t] / 3600 - self.variables['n'][t]
-                                     <= self.M * self.variables['z_imp_lim'][t])
+                                     <= self.grid.p_max_imp * self.time_series.dt[t] / 3600
+                                     * self.variables['z_imp_lim'][t])
                     self.problem += (self.variables['e_imp_lim_exc'][t]
                                      <= self.M * (1 - self.variables['z_imp_lim'][t]))
             else:
@@ -430,7 +441,8 @@ class Optimizer:
                 for t in self.time_steps:
                     self.problem += self.variables['n'][t] <= self.grid.p_max_imp * self.time_series.dt[t] / 3600
                     self.problem += (self.grid.p_max_imp * self.time_series.dt[t] / 3600 - self.variables['n'][t]
-                                     <= self.M * self.variables['z_imp_lim'][t])
+                                     <= self.grid.p_max_imp * self.time_series.dt[t] / 3600
+                                     * self.variables['z_imp_lim'][t])
                     self.problem += (self.variables['e_imp_lim_exc'][t]
                                      <= self.M * (1 - self.variables['z_imp_lim'][t]))
 
@@ -439,7 +451,8 @@ class Optimizer:
             for t in self.time_steps:
                 self.problem += self.variables['e'][t] <= self.grid.p_max_exp * self.time_series.dt[t] / 3600
                 self.problem += (self.grid.p_max_exp * self.time_series.dt[t] / 3600 - self.variables['e'][t]
-                                 <= self.M * self.variables['z_exp_lim'][t])
+                                 <= self.grid.p_max_exp * self.time_series.dt[t] / 3600
+                                 * self.variables['z_exp_lim'][t])
                 self.problem += (self.variables['e_exp_lim_exc'][t]
                                  <= self.M * (1 - self.variables['z_exp_lim'][t]))
 
@@ -514,13 +527,14 @@ class Optimizer:
 
                         # introduce z_p_demand to become only 1 if s_max is almost reached and the
                         # charging with c_min would stop before the end of the time slot
+                        # s is bounded below by 0, so s_max is the largest the left side can get
                         self.problem += ((bat.s_max - self.variables['s'][i][t])
-                                         <= (1 - self.variables['z_p_demand'][i][t]) * self.M
+                                         <= (1 - self.variables['z_p_demand'][i][t]) * bat.s_max
                                          + bat.c_min * self.time_series.dt[t] / 3600.)
 
                         # introduce z_s_max_reached to become only 1 if s_max is fully reached
                         self.problem += ((bat.s_max - self.variables['s'][i][t])
-                                         <= (1 - self.variables['z_s_max_reached'][i][t]) * self.M)
+                                         <= (1 - self.variables['z_s_max_reached'][i][t]) * bat.s_max)
 
                         # set a "soft" constraint to reach the requested charging rate if possible.
                         # deactivate it if s_max is already reached
@@ -532,9 +546,11 @@ class Optimizer:
 
                     if bat.c_min > 0:
                         # set constraints to exclude charging between 0 and c_min if z_p_demand is not 1.
-                        self.problem += (self.variables['c'][i][t] + self.variables['z_p_demand'][i][t] * self.M
+                        self.problem += (self.variables['c'][i][t]
+                                         + bat.c_min * self.time_series.dt[t] / 3600. * self.variables['z_p_demand'][i][t]
                                          >= bat.c_min * self.time_series.dt[t] / 3600. * self.variables['z_c'][i][t])
-                        self.problem += (self.variables['c'][i][t] <= self.M * self.variables['z_c'][i][t])
+                        self.problem += (self.variables['c'][i][t] <= bat.c_max * self.time_series.dt[t] / 3600.
+                                         * self.variables['z_c'][i][t])
 
             # Constraint (7): Minimum charge power limits if there is no charge demand
             elif bat.c_min > 0:
@@ -542,24 +558,29 @@ class Optimizer:
                     # Lower bound: either 0 or at least c_min
                     self.problem += (self.variables['c'][i][t] >= bat.c_min * self.time_series.dt[t] / 3600.
                                      * self.variables['z_c'][i][t])
-                    self.problem += (self.variables['c'][i][t] <= self.M * self.variables['z_c'][i][t])
+                    self.problem += (self.variables['c'][i][t] <= bat.c_max * self.time_series.dt[t] / 3600.
+                                     * self.variables['z_c'][i][t])
 
             # control battery charging from grid
             if not bat.charge_from_grid:
                 for t in self.time_steps:
-                    self.problem += (self.variables['c'][i][t] <= self.M * self.variables['y'][t])
+                    self.problem += (self.variables['c'][i][t] <= bat.c_max * self.time_series.dt[t] / 3600.
+                                     * self.variables['y'][t])
 
             # control battery discharging to grid
             if not bat.discharge_to_grid:
                 for t in self.time_steps:
-                    self.problem += (self.variables['d'][i][t] <= self.M * (1 - self.variables['y'][t]))
+                    self.problem += (self.variables['d'][i][t] <= bat.d_max * self.time_series.dt[t] / 3600.
+                                     * (1 - self.variables['y'][t]))
 
             # lock charging against discharging
             for t in self.time_steps:
                 # Discharge constraint
-                self.problem += self.variables['d'][i][t] <= self.M * self.variables['z_cd'][i][t]
+                self.problem += (self.variables['d'][i][t] <= bat.d_max * self.time_series.dt[t] / 3600.
+                                 * self.variables['z_cd'][i][t])
                 # Charge constraint
-                self.problem += self.variables['c'][i][t] <= self.M * (1 - self.variables['z_cd'][i][t])
+                self.problem += (self.variables['c'][i][t] <= bat.c_max * self.time_series.dt[t] / 3600.
+                                 * (1 - self.variables['z_cd'][i][t]))
 
     def solve(self) -> Dict:
         """

--- a/test_cases/013-grid-export-limit-hit.json
+++ b/test_cases/013-grid-export-limit-hit.json
@@ -199,7 +199,7 @@
     },
     "expected_response": {
         "status": "Optimal",
-        "objective_value": 17.529475918803602,
+        "objective_value": 17.5372629588039,
         "limit_violations": {
             "grid_import_limit_exceeded": false,
             "grid_export_limit_hit": true

--- a/test_cases/019-unexpected-charge-spikes.json
+++ b/test_cases/019-unexpected-charge-spikes.json
@@ -274,7 +274,7 @@
     },
     "expected_response": {
         "status": "Optimal",
-        "objective_value": 1.2393735662576777,
+        "objective_value": 1.2481766551776774,
         "limit_violations": {
             "grid_import_limit_exceeded": false,
             "grid_export_limit_hit": false


### PR DESCRIPTION
Redone on top of main after #95 rewrote the charge demand block and #102 added the ramp penalty. The old two disjunct tightening no longer applies, the new indicators are tightened instead.

Every indicator constraint used the global `M = 1e6` while the largest per step energy in any test case is a few kWh. The relaxation is then nearly vacuous around the binaries: a fractional `z_p_demand` of ~0.003 satisfies the charge demand disjunction while paying neither the charge cost nor the penalty, and the flow direction indicators carry no information at the root. Each M becomes the smallest constant that keeps the inactive branch vacuous, so the integer feasible set is unchanged and the relaxation is strictly tighter.

- `s_max` for the two state of charge gap indicators, `z_p_demand` and `z_s_max_reached`. The state of charge has a lower bound of 0, so `s_max` is the largest value the left side can take
- the per step `c_min` energy for the row that keeps charging out of the band between 0 and `c_min`
- the per step charge and discharge caps for `z_c`, `z_cd` and the grid coupling rows, these are the variables' own upper bounds
- the limit threshold itself for `z_imp_lim` and `z_exp_lim`
- solar plus discharge to grid capacity, and demand plus grid charge capacity, for the flow direction indicators. Only when a grid limit is active does the opposite side's unbounded excess variable enter the balance, and only then does the global M remain
- cases 013 and 019 land on a different point of the same optimal plateau. The full objective is equal to 5.5e-7, only the penalty free `objective_value` decomposition differs, so both expected values are updated

Full suite, median of 5 runs per case, in process through the Flask test client, milliseconds:

| case | main | PR | delta |
|---|---|---|---|
| 009-discharge-before-import | 84.7 | 89.5 | 1.06x |
| 010-infesible-charge-goal | 34.8 | 35.6 | 1.02x |
| 011-infeasible-charge-demand | 82.8 | 69.7 | 0.84x |
| 012-early-charging-not-perfect | 82.2 | 108.8 | 1.32x |
| 013-grid-export-limit-hit | 64.4 | 58.5 | 0.91x |
| 014-grid-import-limit-violation | 42.0 | 45.8 | 1.09x |
| 015-low-soc-initial | 42.3 | 43.4 | 1.03x |
| 016-battery-charge-priotization-1 | 196.7 | 97.9 | 0.50x |
| 017-battery-charge-priotization-2 | 94.7 | 77.1 | 0.81x |
| 018-high-soc-initial | 93.3 | 101.1 | 1.08x |
| 019-unexpected-charge-spikes | 42.8 | 41.5 | 0.97x |
| **020-weird-charging-at-night** | **2422.0** | **668.7** | **0.28x** |
| **021-min-pv-use-case-with-weird-behavior** | **735.5** | **299.4** | **0.41x** |
| 022-feed-in-cap-recovery | 24.8 | 20.2 | 0.81x |
| 023-c_min-limit-kept-with-p_demand-set | 164.6 | 158.0 | 0.96x |
| 024-attenuate-demand-peaks | 25.6 | 20.6 | 0.80x |
| 025-attenuate-feedin-peaks | 22.3 | 19.3 | 0.87x |
| 026-attenuate-grid-peaks | 28.9 | 24.9 | 0.86x |
| 027-attenuate-feedin-peaks-below-cap | 23.0 | 20.4 | 0.89x |
| **TOTAL** | **4307.4** | **2000.4** | **0.46x** |

021 was the one regression in the earlier version of this branch, 0.14s to 0.38s. With the ramp penalty from #102 in main it improves instead. `pytest` wall clock goes from 9.2s to 2.2s. All cases stay Optimal, and the four strict peak shaping cases pass with unchanged schedules.
