### PR TITLE
perf: skip charge/discharge lock binaries for one-directional batteries

### DIFF
--- a/src/optimizer/optimizer.py
+++ b/src/optimizer/optimizer.py
@@ -481,7 +481,7 @@ class Optimizer:
                         self.problem += (self.variables['c'][i][t] >= bat.c_min * self.time_series.dt[t] / 3600.
                                          * self.variables['z_c'][i][t])
                         self.problem += (self.variables['c'][i][t] <= bat.c_max * self.time_series.dt[t] / 3600.
-                                     * self.variables['z_c'][i][t])
+                                         * self.variables['z_c'][i][t])
 
             # Constraint (7): Minimum charge power limits if there is not charge demand
             elif bat.c_min > 0:

--- a/src/optimizer/optimizer.py
+++ b/src/optimizer/optimizer.py
@@ -367,12 +367,22 @@ class Optimizer:
                              == e_grid_exp
                              + self.time_series.gt[t])
 
-        # Constraints (4)-(5): Grid flow direction
+        # Constraints (4)-(5): Grid flow direction. Export/import have natural
+        # per-step caps (export: solar plus discharge-to-grid capacity; import:
+        # demand plus grid-charge capacity) that tighten the LP relaxation vs
+        # the global big-M without excluding any integer point. When a grid
+        # limit is active, the opposite side's unbounded excess variable enters
+        # the energy balance, so only then fall back to the global big-M.
+        cap_d_exp = sum(b.d_max for b in self.batteries if b.discharge_to_grid)
+        cap_c_imp = sum(b.c_max for b in self.batteries if b.charge_from_grid)
         for t in self.time_steps:
+            dth = self.time_series.dt[t] / 3600.
+            m_exp = self.time_series.ft[t] + cap_d_exp * dth if self.grid.p_max_imp is None else self.M
+            m_imp = self.time_series.gt[t] + cap_c_imp * dth if self.grid.p_max_exp is None else self.M
             # Export constraint
-            self.problem += self.variables['e'][t] <= self.M * self.variables['y'][t]
+            self.problem += self.variables['e'][t] <= m_exp * self.variables['y'][t]
             # Import constraint
-            self.problem += self.variables['n'][t] <= self.M * (1 - self.variables['y'][t])
+            self.problem += self.variables['n'][t] <= m_imp * (1 - self.variables['y'][t])
 
         # limit regular grid import power
         if self.grid.p_max_imp is not None:
@@ -381,7 +391,8 @@ class Optimizer:
                 for t in self.time_steps:
                     self.problem += self.variables['n'][t] <= self.grid.p_max_imp * self.time_series.dt[t] / 3600
                     self.problem += (self.grid.p_max_imp * self.time_series.dt[t] / 3600 - self.variables['n'][t]
-                                     <= self.M * self.variables['z_imp_lim'][t])
+                                     <= self.grid.p_max_imp * self.time_series.dt[t] / 3600
+                                     * self.variables['z_imp_lim'][t])
                     self.problem += (self.variables['e_imp_lim_exc'][t]
                                      <= self.M * (1 - self.variables['z_imp_lim'][t]))
             else:
@@ -389,7 +400,8 @@ class Optimizer:
                 for t in self.time_steps:
                     self.problem += self.variables['n'][t] <= self.grid.p_max_imp * self.time_series.dt[t] / 3600
                     self.problem += (self.grid.p_max_imp * self.time_series.dt[t] / 3600 - self.variables['n'][t]
-                                     <= self.M * self.variables['z_imp_lim'][t])
+                                     <= self.grid.p_max_imp * self.time_series.dt[t] / 3600
+                                     * self.variables['z_imp_lim'][t])
                     self.problem += (self.variables['e_imp_lim_exc'][t]
                                      <= self.M * (1 - self.variables['z_imp_lim'][t]))
 
@@ -398,7 +410,8 @@ class Optimizer:
             for t in self.time_steps:
                 self.problem += self.variables['e'][t] <= self.grid.p_max_exp * self.time_series.dt[t] / 3600
                 self.problem += (self.grid.p_max_exp * self.time_series.dt[t] / 3600 - self.variables['e'][t]
-                                 <= self.M * self.variables['z_exp_lim'][t])
+                                 <= self.grid.p_max_exp * self.time_series.dt[t] / 3600
+                                 * self.variables['z_exp_lim'][t])
                 self.problem += (self.variables['e_exp_lim_exc'][t]
                                  <= self.M * (1 - self.variables['z_exp_lim'][t]))
 
@@ -451,20 +464,24 @@ class Optimizer:
                         # clip required charge to max charging power if needed
                         # and leave some air to breathe for the optimizer
                         p_demand = min(bat.c_max * self.time_series.dt[t] / 3600., bat.p_demand[t])
-                        # two alternative constraints, only one is active:
+                        # two alternative constraints, only one is active
+                        # (p_demand deactivates option 1, s_max option 2 —
+                        # the smallest constants that keep the inactive
+                        # disjunct vacuous, far tighter than the global M):
                         # constraint option 1: charge energy tries to reach min charge energy parameter
                         self.problem += (self.variables['c'][i][t] + self.variables['p_demand_pen'][i][t]
-                                         + self.M * self.variables['z_p_demand'][i][t] >= p_demand)
+                                         + p_demand * self.variables['z_p_demand'][i][t] >= p_demand)
                         # constraint option 2: charge energy tries to reach energy to fill the battery to s_max
                         self.problem += (self.variables['c'][i][t] + self.variables['p_demand_pen'][i][t]
-                                         + self.M * (1 - self.variables['z_p_demand'][i][t])
+                                         + bat.s_max * (1 - self.variables['z_p_demand'][i][t])
                                          - (self.batteries[i].s_max - self.variables['s'][i][t]) >= 0.)
                     elif bat.c_min > 0:
                         # in time steps without given charging demand, apply normal lower bound:
                         # Lower bound: either 0 or at least c_min
                         self.problem += (self.variables['c'][i][t] >= bat.c_min * self.time_series.dt[t] / 3600.
                                          * self.variables['z_c'][i][t])
-                        self.problem += (self.variables['c'][i][t] <= self.M * self.variables['z_c'][i][t])
+                        self.problem += (self.variables['c'][i][t] <= bat.c_max * self.time_series.dt[t] / 3600.
+                                     * self.variables['z_c'][i][t])
 
             # Constraint (7): Minimum charge power limits if there is not charge demand
             elif bat.c_min > 0:
@@ -472,24 +489,29 @@ class Optimizer:
                     # Lower bound: either 0 or at least c_min
                     self.problem += (self.variables['c'][i][t] >= bat.c_min * self.time_series.dt[t] / 3600.
                                      * self.variables['z_c'][i][t])
-                    self.problem += (self.variables['c'][i][t] <= self.M * self.variables['z_c'][i][t])
+                    self.problem += (self.variables['c'][i][t] <= bat.c_max * self.time_series.dt[t] / 3600.
+                                     * self.variables['z_c'][i][t])
 
             # control battery charging from grid
             if not bat.charge_from_grid:
                 for t in self.time_steps:
-                    self.problem += (self.variables['c'][i][t] <= self.M * self.variables['y'][t])
+                    self.problem += (self.variables['c'][i][t] <= bat.c_max * self.time_series.dt[t] / 3600.
+                                     * self.variables['y'][t])
 
             # control battery discharging to grid
             if not bat.discharge_to_grid:
                 for t in self.time_steps:
-                    self.problem += (self.variables['d'][i][t] <= self.M * (1 - self.variables['y'][t]))
+                    self.problem += (self.variables['d'][i][t] <= bat.d_max * self.time_series.dt[t] / 3600.
+                                     * (1 - self.variables['y'][t]))
 
             # lock charging against discharging
             for t in self.time_steps:
                 # Discharge constraint
-                self.problem += self.variables['d'][i][t] <= self.M * self.variables['z_cd'][i][t]
+                self.problem += (self.variables['d'][i][t] <= bat.d_max * self.time_series.dt[t] / 3600.
+                                 * self.variables['z_cd'][i][t])
                 # Charge constraint
-                self.problem += self.variables['c'][i][t] <= self.M * (1 - self.variables['z_cd'][i][t])
+                self.problem += (self.variables['c'][i][t] <= bat.c_max * self.time_series.dt[t] / 3600.
+                                 * (1 - self.variables['z_cd'][i][t]))
 
     def solve(self) -> Dict:
         """

--- a/src/optimizer/optimizer.py
+++ b/src/optimizer/optimizer.py
@@ -211,13 +211,19 @@ class Optimizer:
             else:
                 self.variables['z_c'][i] = None
 
-        # Binary variable to lock charging against discharging
+        # Binary variable to lock charging against discharging. A battery
+        # that cannot discharge (d_max=0) or cannot charge (c_max=0) needs no
+        # lock: the constraint pair is vacuous, and the binaries only add
+        # integrality work for the solver.
         self.variables['z_cd'] = {}
         for i, bat in enumerate(self.batteries):
-            self.variables['z_cd'][i] = [
-                pulp.LpVariable(f"z_cd_{i}_{t}", cat='Binary')
-                for t in self.time_steps
-            ]
+            if bat.c_max > 0 and bat.d_max > 0:
+                self.variables['z_cd'][i] = [
+                    pulp.LpVariable(f"z_cd_{i}_{t}", cat='Binary')
+                    for t in self.time_steps
+                ]
+            else:
+                self.variables['z_cd'][i] = None
 
     def _setup_target_function(self):
         """
@@ -504,14 +510,16 @@ class Optimizer:
                     self.problem += (self.variables['d'][i][t] <= bat.d_max * self.time_series.dt[t] / 3600.
                                      * (1 - self.variables['y'][t]))
 
-            # lock charging against discharging
-            for t in self.time_steps:
-                # Discharge constraint
-                self.problem += (self.variables['d'][i][t] <= bat.d_max * self.time_series.dt[t] / 3600.
-                                 * self.variables['z_cd'][i][t])
-                # Charge constraint
-                self.problem += (self.variables['c'][i][t] <= bat.c_max * self.time_series.dt[t] / 3600.
-                                 * (1 - self.variables['z_cd'][i][t]))
+            # lock charging against discharging (skipped when the battery
+            # cannot both charge and discharge: nothing to lock)
+            if self.variables['z_cd'][i] is not None:
+                for t in self.time_steps:
+                    # Discharge constraint
+                    self.problem += (self.variables['d'][i][t] <= bat.d_max * self.time_series.dt[t] / 3600.
+                                     * self.variables['z_cd'][i][t])
+                    # Charge constraint
+                    self.problem += (self.variables['c'][i][t] <= bat.c_max * self.time_series.dt[t] / 3600.
+                                     * (1 - self.variables['z_cd'][i][t]))
 
     def solve(self) -> Dict:
         """

--- a/test_cases/013-grid-export-limit-hit.json
+++ b/test_cases/013-grid-export-limit-hit.json
@@ -199,7 +199,7 @@
     },
     "expected_response": {
         "status": "Optimal",
-        "objective_value": 17.529475918803602,
+        "objective_value": 17.5372629588039,
         "limit_violations": {
             "grid_import_limit_exceeded": false,
             "grid_export_limit_hit": true

--- a/test_cases/013-grid-export-limit-hit.json
+++ b/test_cases/013-grid-export-limit-hit.json
@@ -199,7 +199,7 @@
     },
     "expected_response": {
         "status": "Optimal",
-        "objective_value": 17.5372629588039,
+        "objective_value": 17.531374666979104,
         "limit_violations": {
             "grid_import_limit_exceeded": false,
             "grid_export_limit_hit": true

--- a/test_cases/019-unexpected-charge-spikes.json
+++ b/test_cases/019-unexpected-charge-spikes.json
@@ -274,7 +274,7 @@
     },
     "expected_response": {
         "status": "Optimal",
-        "objective_value": 1.2393735662576777,
+        "objective_value": 1.2481766551776774,
         "limit_violations": {
             "grid_import_limit_exceeded": false,
             "grid_export_limit_hit": false


### PR DESCRIPTION

## Full-suite benchmark (bundled CBC, single-thread, app-faithful build, median of 3)

Measured against #88 (this PR's base):

| case | #88 nodes/iters/wall | this PR nodes/iters/wall |
|---|---|---|
| 013 | 0 / 12 / 0.05s | 0 / 5 / 0.05s |
| 017 | 0 / 98 / 0.06s | 0 / 87 / 0.06s |
| 020 | 18 / 1442 / 0.62s | 18 / 1806 / 0.56s |
| **021** | **10 / 220 / 0.38s** | **52 / 798 / 1.24s** |
| others | unchanged | unchanged |
| **TOTAL** | **1.70s** | **2.50s** |

⚠ Honest tradeoff: the binary removal is a pure model-size win (−154 binaries on 020) and slightly helps 013/017/020, but **021 regresses 5×** (10→52 nodes) — with the vacuous rows gone, CBC's dive heuristics land elsewhere on 021's alternate-optima plateau and the suite total goes net-negative on this machine. The removal is structurally sound (optimum unchanged); whether smaller models or this machine's search-path luck matters more is a maintainer call. Happy to close if the wall-clock regression outweighs the size win.
