### PR TITLE
fix: enforce minimum charge power in charge-demand slots

### DIFF
--- a/src/optimizer/optimizer.py
+++ b/src/optimizer/optimizer.py
@@ -459,15 +459,11 @@ class Optimizer:
                         self.problem += (self.variables['c'][i][t] + self.variables['p_demand_pen'][i][t]
                                          + self.M * (1 - self.variables['z_p_demand'][i][t])
                                          - (self.batteries[i].s_max - self.variables['s'][i][t]) >= 0.)
-                    elif bat.c_min > 0:
-                        # in time steps without given charging demand, apply normal lower bound:
-                        # Lower bound: either 0 or at least c_min
-                        self.problem += (self.variables['c'][i][t] >= bat.c_min * self.time_series.dt[t] / 3600.
-                                         * self.variables['z_c'][i][t])
-                        self.problem += (self.variables['c'][i][t] <= self.M * self.variables['z_c'][i][t])
 
-            # Constraint (7): Minimum charge power limits if there is not charge demand
-            elif bat.c_min > 0:
+            # Constraint (7): Semi-continuous charge power - c is either 0 or >= c_min.
+            # Applied in every time step, including charge-demand slots, so a real charger's
+            # minimum current is respected and the solver cannot pick sub-minimum power.
+            if bat.c_min > 0:
                 for t in self.time_steps:
                     # Lower bound: either 0 or at least c_min
                     self.problem += (self.variables['c'][i][t] >= bat.c_min * self.time_series.dt[t] / 3600.

--- a/tests/test_semicontinuous.py
+++ b/tests/test_semicontinuous.py
@@ -3,8 +3,6 @@ slot, including charge-demand slots. Previously the min-charge constraint was
 skipped whenever p_demand[t] > 0, letting the solver return sub-minimum power
 (e.g. ~950 W for a charger whose real minimum is far higher)."""
 
-import numpy
-
 from optimizer.app import app
 
 C_MIN = 1400.0  # W, e.g. 1p x 230V x ~6A

--- a/tests/test_semicontinuous.py
+++ b/tests/test_semicontinuous.py
@@ -1,0 +1,60 @@
+"""Regression: charge power must be semi-continuous (0 or >= c_min) in every
+slot, including charge-demand slots. Previously the min-charge constraint was
+skipped whenever p_demand[t] > 0, letting the solver return sub-minimum power
+(e.g. ~950 W for a charger whose real minimum is far higher)."""
+
+import numpy
+
+from optimizer.app import app
+
+C_MIN = 1400.0  # W, e.g. 1p x 230V x ~6A
+
+
+def _request(p_demand):
+    # 3 x 1h slots; no solar, charging only from priced grid, stored energy
+    # worthless (p_a=0). Charging is therefore strictly costly, so the solver
+    # charges the minimum needed to meet p_demand - which (pre-fix) is the
+    # sub-c_min demand value itself.
+    return {
+        "batteries": [
+            {
+                "charge_from_grid": True,
+                "s_min": 0.0,
+                "s_max": 10000.0,
+                "s_initial": 0.0,
+                "p_demand": p_demand,
+                "c_min": C_MIN,
+                "c_max": 11000.0,
+                "d_max": 0.0,
+                "p_a": 0.0,
+            }
+        ],
+        "time_series": {
+            "dt": [3600.0, 3600.0, 3600.0],
+            "gt": [0.0, 0.0, 0.0],
+            "ft": [0.0, 0.0, 0.0],  # no solar -> charge only from priced grid
+            "p_N": [0.30, 0.30, 0.30],  # expensive grid import
+            "p_E": [0.0, 0.0, 0.0],  # export worthless
+        },
+    }
+
+
+def _charge_power(response):
+    dt = response.json  # marshalled result
+    powers = dt["batteries"][0]["charging_power"]  # Wh per 1h slot == W
+    return powers
+
+
+def test_charge_demand_below_cmin_is_not_sub_minimum():
+    # demand 500 Wh in slot 0 is BELOW c_min energy (1400 Wh) -> the trap
+    client = app.test_client()
+    resp = client.post("/optimize/charge-schedule", json=_request([500.0, 0.0, 0.0]))
+    assert resp.status_code == 200
+
+    powers = _charge_power(resp)
+    for w in powers:
+        assert w < 1.0 or w >= C_MIN - 1.0, f"sub-minimum charge power {w} W (c_min={C_MIN})"
+
+    # non-vacuous: the demand must actually drive charging (>= c_min), otherwise
+    # the assertion above passes trivially on an all-zero schedule.
+    assert max(powers) >= C_MIN - 1.0, f"expected charging >= c_min, got {powers}"


### PR DESCRIPTION
## Problem

The MILP already models minimum charge power as a semi-continuous variable: charge energy `c` is either `0` or `>= c_min` via the binary `z_c`. But that constraint was only applied in time steps **without** a charge demand:

```python
if bat.p_demand is not None:
    for t in self.time_steps:
        if bat.p_demand[t] > 0:
            <demand constraints only>       # <-- no min-charge bound
        elif bat.c_min > 0:
            <semi-continuous bound>          # only when demand[t] == 0
elif bat.c_min > 0:
    <semi-continuous bound>                  # only when p_demand is None
```

So in exactly the slots where a loadpoint is actively charging (`p_demand[t] > 0`), `c` was free to take any value in `(0, c_min)`. That produces physically impossible schedules — e.g. ~950 W for a wallbox whose real minimum is ~1.4 kW+ (evcc-io/evcc#31894).

## Fix

Apply the semi-continuous bound in every time step for `c_min > 0` batteries, independent of the demand branch. Demand constraints and the min-charge bound now coexist: the solver still tries to meet `p_demand`, but can only do so with `0` or `>= c_min`.

## Test

`tests/test_semicontinuous.py` requests a `500 Wh` demand in a slot while `c_min = 1400 W`, with charging strictly costly (no solar, priced grid, `p_a=0`) so the solver is forced to the cheapest feasible power.

- pre-fix: returns `500 W` (sub-minimum) → test fails
- post-fix: returns `>= c_min` or `0` → test passes

Full suite: 15 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
