### PR TITLE
fix: block single-arch images from reaching production

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,24 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Verify image provides linux/amd64
+        run: |
+          image="${{ env.IMAGE }}:${{ inputs.image_tag || 'latest' }}"
+          # multi-platform tags publish an index; single-platform tags publish a
+          # bare manifest, for which the index template fails and we fall back
+          platforms=$(docker buildx imagetools inspect "$image" \
+              --format '{{range .Manifest.Manifests}}{{.Platform.OS}}/{{.Platform.Architecture}} {{end}}' 2>/dev/null) \
+            || platforms=$(docker buildx imagetools inspect "$image" \
+              --format '{{.Image.OS}}/{{.Image.Architecture}}')
+          echo "$image provides: $platforms"
+          case " $platforms " in
+            *" linux/amd64 "*) ;;
+            *)
+              echo "::error::$image has no linux/amd64 manifest. Container Apps nodes are amd64, so every replica would fail with ImagePullBackOff. Publish via the 'Publish Docker' workflow instead of pushing by hand."
+              exit 1
+              ;;
+          esac
+
       - uses: azure/login@v2
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,11 @@
 DOCKER_IMAGE ?= evcc/optimizer
 DOCKER_TAG ?= latest
+# Container Apps nodes are amd64; an arm64-only tag takes production down
+DOCKER_PLATFORMS ?= linux/amd64,linux/arm64
 
 RESOURCE_GROUP ?= rg-optimizer-prod
 
-default: build docker-build
+default: build docker-build-local
 
 build::
 	go generate ./...
@@ -31,16 +33,19 @@ loadtest::
 	uv run locust --host http://localhost:7050 --headless -t 30s -u 2 --only-summary
 	uv run locust --host http://localhost:7050 --headless -t 30s -u 4 --only-summary
 
-docker: docker-build docker-push docker-run
+docker: docker-build docker-run
 
+# Buildx cannot load a manifest list into the local image store, so a
+# multi-platform tag only exists once pushed to the registry.
 docker-build::
-	docker buildx build . --tag $(DOCKER_IMAGE)
+	docker buildx build . --platform $(DOCKER_PLATFORMS) --tag $(DOCKER_IMAGE):$(DOCKER_TAG) --push
 
-docker-run::
-	docker run -p 7050:7050 -it $(DOCKER_IMAGE)
+# Host architecture only, loaded locally for docker-run. Never push this.
+docker-build-local::
+	docker buildx build . --tag $(DOCKER_IMAGE):$(DOCKER_TAG) --load
 
-docker-push::
-	docker push $(DOCKER_IMAGE)
+docker-run:: docker-build-local
+	docker run -p 7050:7050 -it $(DOCKER_IMAGE):$(DOCKER_TAG)
 
 fly::
 	fly deploy --local-only


### PR DESCRIPTION
## Why

`evcc/optimizer:latest` pushed by hand on 2026-07-24T13:26Z carried only a `linux/arm64` manifest. Azure Container Apps nodes are amd64, found no matching manifest, and every replica looped in `ImagePullBackOff` — `optimizer.evcc.io` was down until `latest` was rebuilt multi-arch. Every earlier tag was `amd64+arm64`; there was no `Publish Docker` run that day, so the buildx path was bypassed.

Nothing in the pipeline noticed. `deploy.yml` deployed the broken tag to 100% traffic a minute after the push.

## What

**`deploy.yml`** — inspects the tag before touching Azure, fails with an explicit error if `linux/amd64` is absent. Multi-platform tags publish an index (`.Manifest.Manifests`); single-platform tags publish a bare manifest, for which that template exits 1 and the fallback reads the config blob.

**`Makefile`** — `docker-build` now builds `linux/amd64,linux/arm64` (override via `DOCKER_PLATFORMS`).

## Behaviour changes worth reviewing

Buildx cannot load a manifest list into the local image store, so a multi-platform tag only exists once pushed. Consequences:

- `docker-build` pushes directly; the separate `docker-push` target is gone.
- Local iteration moves to `docker-build-local` — host arch, `--load`, never pushes.
- `default` uses `docker-build-local`, so a bare `make` no longer publishes anything (previously it built a local image that a later `make docker-push` could ship single-arch — the exact outage path).

## Verification

Check logic run against the real registry, all three manifest shapes:

| image | resolved platforms | result |
|---|---|---|
| `latest` (multi-arch) | `linux/amd64 linux/arm64` | pass |
| `eacd365…` (single-arch amd64) | `linux/amd64` | pass, via fallback |
| `sha256:29a91f79…` (the outage image) | `linux/arm64` | **fail**, as intended |

`deploy.yml` parses as YAML with the step in the right position; Actions leaves the bare Go-template braces alone. `make -n` for `default`, `docker-build`, `docker-run` all expand as intended.

Not covered: the check reads the tag at deploy time, so a tag overwritten between check and pull still slips through. Digest-pinned deploys would close that; out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
