### PR TITLE
infra: right size replicas and workers to the CPU bound solve

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -81,16 +81,20 @@ resource containerApp 'Microsoft.App/containerApps@2025-01-01' = {
         {
           name: 'optimizer'
           image: containerImage
+          // one vCPU per replica keeps allocation close to demand. The solve is CPU bound,
+          // so a coarser replica rounds up into cores that are paid for and never used.
           resources: {
-            cpu: json('2')
-            memory: '4Gi'
+            cpu: json('1')
+            memory: '2Gi'
           }
           env: [
             { name: 'OPTIMIZER_TIME_LIMIT', value: '20' }
             { name: 'OPTIMIZER_NUM_THREADS', value: '1' }
             {
               name: 'GUNICORN_CMD_ARGS'
-              value: '--workers 8 --timeout 40 --max-requests 100 --max-requests-jitter 500'
+              // one worker per vCPU. Oversubscribing a CPU bound solver only moves the queue
+              // from the ingress into the kernel scheduler and inflates tail latency.
+              value: '--workers 2 --timeout 40 --max-requests 100 --max-requests-jitter 500'
             }
             { name: 'JWT_TOKEN_SECRET', secretRef: 'jwt-token-secret' }
           ]
@@ -109,12 +113,24 @@ resource containerApp 'Microsoft.App/containerApps@2025-01-01' = {
       scale: {
         minReplicas: 1
         maxReplicas: 50
+        // KEDA takes the maximum over both rules. The CPU rule is the one that matches the
+        // bottleneck, the concurrency rule stays as a fast reacting guard for bursts.
         rules: [
           {
             name: 'http-scaling'
             http: {
               metadata: {
-                concurrentRequests: '16'
+                concurrentRequests: '8'
+              }
+            }
+          }
+          {
+            name: 'cpu-scaling'
+            custom: {
+              type: 'cpu'
+              metadata: {
+                type: 'Utilization'
+                value: '75'
               }
             }
           }


### PR DESCRIPTION
Follows the cost analysis of the 24 June to 24 July window. Pairs with #88, which cuts the CPU per request that this sizing is built around.

The 30 day bill for rg-optimizer-prod is 248.46 EUR, of which 245.20 is vCPU and memory. Memory is locked to 2 GiB per vCPU on the Consumption profile, so allocated vCPU is effectively the whole bill, at 71.30 EUR per vCPU month. Measured over the window: 3.44 vCPU allocated on average against 1.81 used, 54 percent utilization, never above 80, with traffic almost flat at a peak to mean ratio of 1.24. That much headroom buys very little.

- replicas go from 2 vCPU / 4 GiB to 1 vCPU / 2 GiB, so allocation rounds up in smaller steps
- a CPU utilization rule at 75 percent joins the concurrency rule. KEDA takes the maximum of the two, so the CPU rule tracks the actual bottleneck while the concurrency rule stays as a fast reacting burst guard
- concurrency target drops from 16 to 8 in step with the halved replica
- gunicorn goes from 8 workers to 2, one per vCPU. Eight workers on two cores oversubscribed the solver by 4x, which moves the queue from the ingress into the kernel scheduler. That is the most plausible source of the 53 worker timeouts at 40 seconds in the window, since the solver itself is capped at 20

At 75 percent utilization the same load needs 2.41 vCPU instead of 3.44, about 70 EUR per month. With #88 on top the expected steady state is roughly 100 to 110 EUR per month against 248 today.

There is no per request latency anywhere in metrics or logs, so the worker sizing is reasoned from CPU seconds per request rather than measured. Worth landing an access log with response time before tuning any further.
