### PR TITLE
infra: log request latency instead of the token subject

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ COPY --from=builder --chown=app:app /app/.venv /app/.venv
 ENV PYTHONUNBUFFERED=1
 ENV OPTIMIZER_TIME_LIMIT=25
 ENV OPTIMIZER_NUM_THREADS=1
-ENV GUNICORN_CMD_ARGS="--workers 4 --max-requests 32" 
+# the access log is the only source of per request latency, keep the format lean
+ENV GUNICORN_CMD_ARGS="--workers 4 --max-requests 32 --access-logfile - --access-logformat '%(m)s %(U)s %(s)s %(D)s'"
 USER app
 CMD ["/app/.venv/bin/gunicorn", "--bind", "0.0.0.0:7050", "optimizer.app:app"]

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -94,7 +94,9 @@ resource containerApp 'Microsoft.App/containerApps@2025-01-01' = {
               name: 'GUNICORN_CMD_ARGS'
               // one worker per vCPU. Oversubscribing a CPU bound solver only moves the queue
               // from the ingress into the kernel scheduler and inflates tail latency.
-              value: '--workers 2 --timeout 40 --max-requests 100 --max-requests-jitter 500'
+              // the access log is the only source of per request latency. %(D)s is the
+              // response time in microseconds, the rest of the format stays lean on purpose.
+              value: '--workers 2 --timeout 40 --max-requests 100 --max-requests-jitter 500 --access-logfile - --access-logformat \'%(m)s %(U)s %(s)s %(D)s\''
             }
             { name: 'JWT_TOKEN_SECRET', secretRef: 'jwt-token-secret' }
           ]

--- a/src/optimizer/app.py
+++ b/src/optimizer/app.py
@@ -23,8 +23,7 @@ def before_request_func():
             if token_type.lower() != 'bearer':
                 return jsonify({"message": "Invalid token type"}), 401
 
-            payload = jwt.decode(token, secret_key, algorithms=["HS256"])
-            print("subject:", payload.get('sub'))
+            jwt.decode(token, secret_key, algorithms=["HS256"])
         except jwt.ExpiredSignatureError:
             return jsonify({"message": "Token has expired"}), 401
         except jwt.InvalidTokenError:

--- a/src/optimizer/app.py
+++ b/src/optimizer/app.py
@@ -6,8 +6,10 @@ from flask_restx import Api, Resource, fields
 from werkzeug.exceptions import BadRequest
 
 from .optimizer import BatteryConfig, GridConfig, OptimizationStrategy, Optimizer, TimeSeriesData
+from .settings import OptimizerSettings
 
 app = Flask(__name__)
+settings = OptimizerSettings()
 
 
 @app.before_request
@@ -23,7 +25,9 @@ def before_request_func():
             if token_type.lower() != 'bearer':
                 return jsonify({"message": "Invalid token type"}), 401
 
-            jwt.decode(token, secret_key, algorithms=["HS256"])
+            payload = jwt.decode(token, secret_key, algorithms=["HS256"])
+            if settings.log_subject:
+                print("subject:", payload.get('sub'))
         except jwt.ExpiredSignatureError:
             return jsonify({"message": "Token has expired"}), 401
         except jwt.InvalidTokenError:

--- a/src/optimizer/settings.py
+++ b/src/optimizer/settings.py
@@ -7,3 +7,4 @@ class OptimizerSettings(BaseSettings):
 
     num_threads: int | None = Field(default=None, description="Number of threads to use for optimization")
     time_limit: float | None = Field(default=None, description="Time limit for the optimization process in seconds")
+    log_subject: bool = Field(default=False, description="Log the JWT subject of every request. Off by default, it names accounts in the logs")

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2,10 +2,11 @@
 import json
 import pathlib
 
+import jwt
 import numpy
 import pytest
 
-from optimizer.app import app
+from optimizer.app import app, settings
 
 
 @pytest.mark.parametrize('test_case', pathlib.Path('test_cases').glob('*.json'))
@@ -63,6 +64,21 @@ def test_optimizer(test_case: pathlib.Path):
                 room = battery["s_max"] - soc[t]
                 assert charge <= 1 or charge >= step - 1 or room <= step + 1, \
                     f"battery {i} t={t}: charges {charge} below c_min step {step} with {room} Wh room to s_max"
+
+
+def test_subject_logging_is_configurable(capsys, monkeypatch):
+    monkeypatch.setenv("JWT_TOKEN_SECRET", "test-secret")
+    token = jwt.encode({"sub": "someone"}, "test-secret", algorithm="HS256")
+    client = app.test_client()
+    headers = {"Authorization": f"Bearer {token}"}
+
+    monkeypatch.setattr(settings, "log_subject", False)
+    client.post("/optimize/charge-schedule", json={}, headers=headers)
+    assert "subject:" not in capsys.readouterr().out
+
+    monkeypatch.setattr(settings, "log_subject", True)
+    client.post("/optimize/charge-schedule", json={}, headers=headers)
+    assert "subject: someone" in capsys.readouterr().out
 
 
 def test_abort_returns_json_message():


### PR DESCRIPTION
Follows #111, which sized replicas and workers without any latency data to size them against.

Nothing in the deployment records per request latency. Gunicorn runs without an access log, Container Apps exposes no latency metric, and the 6.3 million console log lines a month carry only the token subject. Replica and worker sizing in #111 therefore had to be reasoned from CPU seconds per request rather than measured, and the 53 worker timeouts in the last 30 days cannot be attributed to anything.

- gunicorn logs to stdout with `--access-logformat '%(m)s %(U)s %(s)s %(D)s'`: method, path, status, response time in microseconds. No remote address, no referrer, no user agent, so a line stays shorter than the subject line it replaces
- subject logging moves behind `OPTIMIZER_LOG_SUBJECT`, off by default. It names accounts in the logs and Log Analytics keeps them for 30 days, so it is worth switching on deliberately and for as long as it is needed rather than permanently. Set the env var on the container app to get the old behaviour back
- both the Dockerfile default and the container app override carry the same gunicorn flags, so a local `make docker-run` logs what production logs

After this is deployed, `ContainerAppConsoleLogs_CL` can answer p50, p95 and p99 per endpoint, which is what the worker count and the concurrency target should be tuned against.
