### PR TITLE
feat: dump requests that exhaust the solver time limit

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -91,8 +91,8 @@ resource containerApp 'Microsoft.App/containerApps@2025-01-01' = {
             { name: 'OPTIMIZER_TIME_LIMIT', value: '20' }
             { name: 'OPTIMIZER_NUM_THREADS', value: '1' }
             // roughly 2 percent of requests exhaust the time limit. Keep them for replay.
-            // The dump directory is ephemeral, a replica restart takes its contents with it.
-            { name: 'OPTIMIZER_DUMP_SLOW_REQUESTS', value: 'true' }
+            // The file is ephemeral, a replica restart takes it with it.
+            { name: 'OPTIMIZER_DUMP_SLOW_REQUESTS', value: '/tmp/slow-requests.jsonl' }
             {
               name: 'GUNICORN_CMD_ARGS'
               // one worker per vCPU. Oversubscribing a CPU bound solver only moves the queue

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -90,6 +90,9 @@ resource containerApp 'Microsoft.App/containerApps@2025-01-01' = {
           env: [
             { name: 'OPTIMIZER_TIME_LIMIT', value: '20' }
             { name: 'OPTIMIZER_NUM_THREADS', value: '1' }
+            // roughly 2 percent of requests exhaust the time limit. Keep them for replay.
+            // The dump directory is ephemeral, a replica restart takes its contents with it.
+            { name: 'OPTIMIZER_DUMP_SLOW_REQUESTS', value: 'true' }
             {
               name: 'GUNICORN_CMD_ARGS'
               // one worker per vCPU. Oversubscribing a CPU bound solver only moves the queue

--- a/src/optimizer/app.py
+++ b/src/optimizer/app.py
@@ -1,3 +1,4 @@
+import fcntl
 import json
 import os
 import pathlib
@@ -46,16 +47,21 @@ def dump_slow_request(payload, elapsed):
     The elapsed time covers model building as well as solving, so a request that only exceeds
     the limit while building is caught too. That one is equally worth looking at.
     """
-    limit = settings.time_limit
-    if not settings.dump_slow_requests or limit is None or elapsed < limit:
+    path, limit = settings.dump_slow_requests, settings.time_limit
+    if not path or limit is None or elapsed < limit:
         return
 
+    # one line per request, carrying the same "request" key as test_cases/*.json so a line
+    # can be replayed by the existing harness
+    line = json.dumps({"ts": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+                       "elapsed": round(elapsed, 3), "request": payload}) + "\n"
     try:
-        directory = pathlib.Path(settings.dump_dir)
-        directory.mkdir(parents=True, exist_ok=True)
-        name = f"{datetime.now(timezone.utc):%Y%m%dT%H%M%S%f}-{os.getpid()}.json"
-        # same shape as test_cases/*.json, so a dump can be replayed by the existing harness
-        (directory / name).write_text(json.dumps({"request": payload}, indent=1))
+        pathlib.Path(path).parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "a") as f:
+            # every gunicorn worker appends to the same file, and a request is far larger than
+            # the buffer size that would make the append atomic on its own
+            fcntl.flock(f, fcntl.LOCK_EX)
+            f.write(line)
     except OSError as e:
         # a full or read only disk must never turn a solved request into an error
         print("could not dump slow request:", e)

--- a/src/optimizer/app.py
+++ b/src/optimizer/app.py
@@ -1,4 +1,8 @@
+import json
 import os
+import pathlib
+import time
+from datetime import datetime, timezone
 
 import jwt
 from flask import Flask, jsonify, request
@@ -34,6 +38,27 @@ def before_request_func():
             return jsonify({"message": "Invalid token"}), 401
         except Exception as e:
             return jsonify({"message": str(e)}), 401
+
+
+def dump_slow_request(payload, elapsed):
+    """Persist requests that exhausted the solver time limit, they are the ones worth replaying.
+
+    The elapsed time covers model building as well as solving, so a request that only exceeds
+    the limit while building is caught too. That one is equally worth looking at.
+    """
+    limit = settings.time_limit
+    if not settings.dump_slow_requests or limit is None or elapsed < limit:
+        return
+
+    try:
+        directory = pathlib.Path(settings.dump_dir)
+        directory.mkdir(parents=True, exist_ok=True)
+        name = f"{datetime.now(timezone.utc):%Y%m%dT%H%M%S%f}-{os.getpid()}.json"
+        # same shape as test_cases/*.json, so a dump can be replayed by the existing harness
+        (directory / name).write_text(json.dumps({"request": payload}, indent=1))
+    except OSError as e:
+        # a full or read only disk must never turn a solved request into an error
+        print("could not dump slow request:", e)
 
 
 api = Api(app, version='1.0', title='EV Charging Optimization API',
@@ -217,7 +242,9 @@ class OptimizeCharging(Resource):
                 M=1e6
             )
 
+            started = time.perf_counter()
             result = optimizer.solve()
+            dump_slow_request(data, time.perf_counter() - started)
             return result
 
         except Exception as e:

--- a/src/optimizer/settings.py
+++ b/src/optimizer/settings.py
@@ -8,5 +8,5 @@ class OptimizerSettings(BaseSettings):
     num_threads: int | None = Field(default=None, description="Number of threads to use for optimization")
     time_limit: float | None = Field(default=None, description="Time limit for the optimization process in seconds")
     log_subject: bool = Field(default=False, description="Log the JWT subject of every request. Off by default, it names accounts in the logs")
-    dump_slow_requests: bool = Field(default=False, description="Write requests that exhaust the solver time limit to disk so they can be replayed")
-    dump_dir: str = Field(default="/tmp/slow-requests", description="Directory the slow request dumps are written to")
+    dump_slow_requests: str | None = Field(default=None,
+                                           description="JSON Lines file requests that exhaust the solver time limit are appended to. Unset disables the dump")

--- a/src/optimizer/settings.py
+++ b/src/optimizer/settings.py
@@ -8,3 +8,5 @@ class OptimizerSettings(BaseSettings):
     num_threads: int | None = Field(default=None, description="Number of threads to use for optimization")
     time_limit: float | None = Field(default=None, description="Time limit for the optimization process in seconds")
     log_subject: bool = Field(default=False, description="Log the JWT subject of every request. Off by default, it names accounts in the logs")
+    dump_slow_requests: bool = Field(default=False, description="Write requests that exhaust the solver time limit to disk so they can be replayed")
+    dump_dir: str = Field(default="/tmp/slow-requests", description="Directory the slow request dumps are written to")

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -81,6 +81,24 @@ def test_subject_logging_is_configurable(capsys, monkeypatch):
     assert "subject: someone" in capsys.readouterr().out
 
 
+def test_slow_requests_are_dumped(tmp_path, monkeypatch):
+    request = json.loads(pathlib.Path('test_cases/009-discharge-before-import.json').read_text())["request"]
+    client = app.test_client()
+    monkeypatch.setattr(settings, "dump_dir", str(tmp_path))
+    # a limit of zero makes every solve count as exhausting it
+    monkeypatch.setattr(settings, "time_limit", 0)
+
+    monkeypatch.setattr(settings, "dump_slow_requests", False)
+    client.post("/optimize/charge-schedule", json=request)
+    assert list(tmp_path.glob("*.json")) == []
+
+    monkeypatch.setattr(settings, "dump_slow_requests", True)
+    client.post("/optimize/charge-schedule", json=request)
+    dumps = list(tmp_path.glob("*.json"))
+    assert len(dumps) == 1
+    assert json.loads(dumps[0].read_text())["request"] == request
+
+
 def test_abort_returns_json_message():
     # message-only api.abort(400, ...) must return a JSON body, not an empty response
     client = app.test_client()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -83,20 +83,22 @@ def test_subject_logging_is_configurable(capsys, monkeypatch):
 
 def test_slow_requests_are_dumped(tmp_path, monkeypatch):
     request = json.loads(pathlib.Path('test_cases/009-discharge-before-import.json').read_text())["request"]
+    dump = tmp_path / "nested" / "slow.jsonl"
     client = app.test_client()
-    monkeypatch.setattr(settings, "dump_dir", str(tmp_path))
     # a limit of zero makes every solve count as exhausting it
     monkeypatch.setattr(settings, "time_limit", 0)
 
-    monkeypatch.setattr(settings, "dump_slow_requests", False)
+    monkeypatch.setattr(settings, "dump_slow_requests", None)
     client.post("/optimize/charge-schedule", json=request)
-    assert list(tmp_path.glob("*.json")) == []
+    assert not dump.exists()
 
-    monkeypatch.setattr(settings, "dump_slow_requests", True)
+    monkeypatch.setattr(settings, "dump_slow_requests", str(dump))
     client.post("/optimize/charge-schedule", json=request)
-    dumps = list(tmp_path.glob("*.json"))
-    assert len(dumps) == 1
-    assert json.loads(dumps[0].read_text())["request"] == request
+    client.post("/optimize/charge-schedule", json=request)
+    lines = dump.read_text().splitlines()
+    assert len(lines) == 2, "every slow request appends one line"
+    assert json.loads(lines[0])["request"] == request
+    assert json.loads(lines[1])["elapsed"] > 0
 
 
 def test_abort_returns_json_message():


### PR DESCRIPTION
Follows #112, whose access log showed that about 2 percent of optimize calls run into `OPTIMIZER_TIME_LIMIT` and return whatever the solver has at 20 seconds. The p99 is pinned there. Those are the requests worth studying, and right now none of them is kept.

- `OPTIMIZER_DUMP_SLOW_REQUESTS` takes the path of a JSON Lines file. Every request whose solve exceeds the time limit is appended as one line. Unset, the default, disables the dump entirely
- production writes to `/tmp/slow-requests.jsonl`
- a line carries `ts`, `elapsed` and `request`, and the `request` key holds exactly what `test_cases/*.json` holds, so a line can be replayed by the existing harness
- the append takes an exclusive `flock`. Every gunicorn worker writes to the same file and a request is far larger than the buffer size that would make the append atomic on its own
- the elapsed time covers model building as well as solving, so a request that only exceeds the limit while building is captured too
- a failing write is logged and swallowed. A full or read only disk must never turn a solved request into an error

The file is ephemeral, a replica restart takes it with it, and replicas currently come and go on a one minute scale. That is fine for pulling a handful of pathological cases out of production by hand, and not enough if these should be collected reliably. A volume mount or shipping the lines to blob storage would be the next step, once we know what the captured requests actually look like.
