### PR TITLE
perf: cut the solver time limit to 10s

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ COPY --from=builder --chown=app:app /app/.venv /app/.venv
 
 # Run the application
 ENV PYTHONUNBUFFERED=1
-ENV OPTIMIZER_TIME_LIMIT=25
+ENV OPTIMIZER_TIME_LIMIT=10
 ENV OPTIMIZER_NUM_THREADS=1
 # the access log is the only source of per request latency, keep the format lean
 ENV GUNICORN_CMD_ARGS="--workers 4 --max-requests 32 --access-logfile - --access-logformat '%(m)s %(U)s %(s)s %(D)s'"

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -88,9 +88,13 @@ resource containerApp 'Microsoft.App/containerApps@2025-01-01' = {
             memory: '2Gi'
           }
           env: [
-            { name: 'OPTIMIZER_TIME_LIMIT', value: '20' }
+            // requests that reach the limit walk a cost optimal plateau rather than close a gap:
+            // replaying 20 collected ones, 17 end on the same objective at 10 s as at 20 s. The
+            // exception cost 4.7 percent, so this halves the latency and the core they hold on a
+            // one vCPU replica at the price of a worse schedule for a small share of them.
+            { name: 'OPTIMIZER_TIME_LIMIT', value: '10' }
             { name: 'OPTIMIZER_NUM_THREADS', value: '1' }
-            // roughly 2 percent of requests exhaust the time limit. Keep them for replay.
+            // the dump threshold is the time limit, so this collects everything above 10 s now.
             // The file is ephemeral, a replica restart takes it with it.
             { name: 'OPTIMIZER_DUMP_SLOW_REQUESTS', value: '/tmp/slow-requests.jsonl' }
             {


### PR DESCRIPTION
Cuts the solver time limit from 20 s (Azure) / 25 s (image default) to 10 s.

## Why

Requests that exhaust the limit are not requests that are closing a gap — they walk a cost
optimal plateau until the clock runs out. Every second past the last incumbent improvement is
tail latency and a held core on a CPU bound, one vCPU replica.

## Measurement

20 requests sampled from the 729 slow requests collected in production (all of them had
exhausted the 20 s limit there), replayed with `OPTIMIZER_NUM_THREADS=1` like production, one
solve at a time so no run steals CPU from another. The objective is maximized, so a negative
gap is a worse schedule.

| limit vs 20 s | same objective | better | worse | worst case |
|---------------|----------------|--------|-------|------------|
| 10 s          | 17/20          | 2      | 1     | **−4.68 %** |

The two "better" cases are search path luck, not a systematic win: +0.24 % and +0.13 %.

A 60 s reference over the same sample puts 20 s within 0.37 % of it, so 20 s is not the optimum
either — both limits stop on the plateau, only at different points.

Sweeping the one regressing case plus the two noisy ones across more limits shows where the
cost sits:

| limit | 10 s | 12 s | 15 s | 18 s | 20 s |
|-------|------|------|------|------|------|
| objective | 4.3303 | 4.3303 | 4.5432 | 4.5432 | 4.5432 |

That case finds its better incumbent between 12 s and 15 s. **15 s would be the loss free
setting** on this sample; 10 s buys another 5 s of latency for a −4.7 % schedule on roughly one
in twenty slow requests. Slow requests are about 2 % of traffic, so that is on the order of
0.1 % of all requests. Flip the value if that trade is not worth it.

## Also

The dump threshold is the time limit itself, so `/tmp/slow-requests.jsonl` now collects
everything above 10 s instead of above 20 s — more lines per replica, still ephemeral.

Reproduce with the collected log: sample requests from `slow-requests.jsonl` (see `make slow`),
POST each to `/optimize/charge-schedule` with `OPTIMIZER_TIME_LIMIT` set per run and compare
`objective_value`.
