### PR TITLE
fix: stop a killed worker from stranding its solver on a core

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,8 @@ COPY --from=builder --chown=app:app /app/.venv /app/.venv
 ENV PYTHONUNBUFFERED=1
 ENV OPTIMIZER_TIME_LIMIT=10
 ENV OPTIMIZER_NUM_THREADS=1
-# the access log is the only source of per request latency, keep the format lean
-ENV GUNICORN_CMD_ARGS="--workers 4 --max-requests 32 --access-logfile - --access-logformat '%(m)s %(U)s %(s)s %(D)s'"
+# the access log is the only source of per request latency, keep the format lean.
+# the config module reaps solvers left behind by a killed worker, see gunicorn_conf.py
+ENV GUNICORN_CMD_ARGS="--workers 4 --max-requests 32 --config python:optimizer.gunicorn_conf --access-logfile - --access-logformat '%(m)s %(U)s %(s)s %(D)s'"
 USER app
 CMD ["/app/.venv/bin/gunicorn", "--bind", "0.0.0.0:7050", "optimizer.app:app"]

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -99,11 +99,15 @@ resource containerApp 'Microsoft.App/containerApps@2025-01-01' = {
             { name: 'OPTIMIZER_DUMP_SLOW_REQUESTS', value: '/tmp/slow-requests.jsonl' }
             {
               name: 'GUNICORN_CMD_ARGS'
-              // one worker per vCPU. Oversubscribing a CPU bound solver only moves the queue
-              // from the ingress into the kernel scheduler and inflates tail latency.
+              // one worker per vCPU, and the replica carries one. Two workers on one core let
+              // a pair of concurrent solves halve each other's speed, which pushed a 20 s solve
+              // past the request timeout and cost a worker, and with it a core, for good.
+              // the timeout sits above the worst elapsed time seen in production, 29 s, so it
+              // catches a genuinely stuck request without cutting a legitimate solve short.
+              // the config module reaps a solver that outlived its worker anyway.
               // the access log is the only source of per request latency. %(D)s is the
               // response time in microseconds, the rest of the format stays lean on purpose.
-              value: '--workers 2 --timeout 40 --max-requests 100 --max-requests-jitter 500 --access-logfile - --access-logformat \'%(m)s %(U)s %(s)s %(D)s\''
+              value: '--workers 1 --timeout 60 --max-requests 100 --max-requests-jitter 500 --config python:optimizer.gunicorn_conf --access-logfile - --access-logformat \'%(m)s %(U)s %(s)s %(D)s\''
             }
             { name: 'JWT_TOKEN_SECRET', secretRef: 'jwt-token-secret' }
           ]

--- a/src/optimizer/gunicorn_conf.py
+++ b/src/optimizer/gunicorn_conf.py
@@ -1,0 +1,51 @@
+"""gunicorn hooks. Wired with --config python:optimizer.gunicorn_conf.
+
+A worker killed by --timeout dies by SIGKILL, so nothing in the worker runs on the way
+out. PuLP solves by shelling out to cbc, and that child survives its parent: the -sec
+limit stops belonging to anything once the parent is gone, so the orphan keeps a core
+busy for as long as the replica lives. Six of eleven replicas were carrying one on
+2026-07-25, two of them with more than five core hours on the clock each.
+
+child_exit runs in the master, which is the one hook a SIGKILLed worker still triggers.
+"""
+import os
+import signal
+
+
+def orphaned_solvers(proc="/proc", name="cbc"):
+    """PIDs of `name` processes that have been reparented to PID 1.
+
+    The master runs as PID 1 in the container, so a solver whose worker is gone lands on
+    it. A solver still owned by a live worker names that worker as its parent, never 1,
+    which is what keeps this from killing a running solve.
+    """
+    try:
+        entries = os.listdir(proc)
+    except OSError:
+        # no procfs, which is a development machine rather than the container
+        return
+    for entry in entries:
+        if not entry.isdigit():
+            continue
+        try:
+            with open(os.path.join(proc, entry, "comm")) as f:
+                if f.read().strip() != name:
+                    continue
+            with open(os.path.join(proc, entry, "stat")) as f:
+                # comm sits in parens and may hold spaces, so split off the last ')' first.
+                # The fields after it are state, ppid, ...
+                if f.read().rsplit(")", 1)[1].split()[1] != "1":
+                    continue
+        except (OSError, IndexError):
+            # the process ended while being read, which is the outcome we wanted anyway
+            continue
+        yield int(entry)
+
+
+def child_exit(server, worker):
+    for pid in orphaned_solvers():
+        server.log.warning("reaping orphaned solver %s left by worker %s", pid, worker.pid)
+        try:
+            os.kill(pid, signal.SIGKILL)
+        except OSError as e:
+            server.log.warning("could not reap solver %s: %s", pid, e)

--- a/tests/test_gunicorn_conf.py
+++ b/tests/test_gunicorn_conf.py
@@ -1,0 +1,27 @@
+from optimizer.gunicorn_conf import orphaned_solvers
+
+
+def fake_proc(root, pid, comm, ppid):
+    entry = root / str(pid)
+    entry.mkdir()
+    (entry / "comm").write_text(comm + "\n")
+    # the real format, comm in parens between pid and state
+    (entry / "stat").write_text(f"{pid} ({comm}) R {ppid} {pid} 0 0 -1 4194304 500 0\n")
+
+
+def test_only_reparented_solvers_are_picked_up(tmp_path):
+    fake_proc(tmp_path, 1, "gunicorn", 0)
+    fake_proc(tmp_path, 20, "gunicorn", 1)        # a live worker
+    fake_proc(tmp_path, 30, "cbc", 20)            # solving for that worker, must survive
+    fake_proc(tmp_path, 40, "cbc", 1)             # orphan, its worker was killed
+    fake_proc(tmp_path, 50, "python3", 1)         # reparented, but not a solver
+    (tmp_path / "self").mkdir()                   # /proc holds non numeric entries too
+
+    assert list(orphaned_solvers(str(tmp_path))) == [40]
+
+
+def test_a_process_ending_mid_read_is_skipped(tmp_path):
+    fake_proc(tmp_path, 40, "cbc", 1)
+    (tmp_path / "41").mkdir()  # exited between listdir and open, so it has no comm
+
+    assert list(orphaned_solvers(str(tmp_path))) == [40]


### PR DESCRIPTION
## What happened

Cutting `OPTIMIZER_TIME_LIMIT` to 10s (#116) did exactly what it promised — p99 20.6s → 10.6s, replicas 5 → 3, run rate €520 → €233/month. Then over the next eight hours the fleet climbed to 11 replicas and stayed there, at **€799/month against €365 before the cut**, on unchanged traffic (~9,700 req/h throughout).

The cut is not what burned the CPU. It removed the headroom that had been hiding a latent bug.

## The chain

1. At 3 replicas each replica is `cpu: 1` running `--workers 2`. Two solves landing together share one core, so each takes twice as long in wall time and a 20s worst case becomes 40s.
2. 40s is `--timeout 40`. gunicorn SIGKILLs the worker mid-solve.
3. PuLP solves via `pulp.PULP_CBC_CMD` (`src/optimizer/optimizer.py:595`), so the kill lands on the Python parent and leaves the `cbc` child running. Its `-sec 10.0` stops belonging to anything once the parent is gone.
4. The replica never gets that core share back. Eight `WORKER TIMEOUT` events on six of eleven replicas, and each one's median response time doubles in the hour of its kill and holds for 16h. `RestartCount` = 0, so nothing reaps them.
5. KEDA reads the loss as load and adds replicas. Damaged replicas are never evicted, so the fleet parks at 11 — while per-replica CPU sits at 62% against a 75% target and ~3.6 requests are in flight against a rule of 8 per replica. Neither scale rule justifies 11; Container Apps bills the whole allocated vCPU + 2 GiB of each anyway.

Confirmed by reading `/proc` in the containers:

| replica | worker timeouts | p50 | stray `cbc` | CPU burned by strays |
|---|---|---|---|---|
| `p4tzc` | 2 | 1.20s | **2** | 20,847s + 18,127s |
| `mfvtd` | 0 | 0.39s | 0 | — |

Both strays were launched with `-sec 10.0 -threads 1 -timeMode elapsed` and had each been running for hours.

## The changes

- **`--workers 2` → `1`.** One worker per vCPU. Two workers on one core is what manufactures the 40s wall time in the first place; the comment above this line already argued for it.
- **`--timeout 40` → `60`.** Above the worst elapsed time seen in production (29s), so it still catches a genuinely stuck request without cutting a legitimate solve short.
- **`src/optimizer/gunicorn_conf.py`**, wired with `--config python:optimizer.gunicorn_conf`. A `child_exit` hook — the one hook a SIGKILLed worker still triggers, since it runs in the master — kills any `cbc` that has been reparented to PID 1. The master *is* PID 1 in this container, so that is a reliable orphan signal; a solver owned by a live worker names that worker as its parent, so a running solve is never at risk.

The first two remove the cause, the third is the belt to their braces — an orphan can also come from an OOM kill.

## Verification

- `uv run pytest` — 24 passed, including two new cases covering orphan selection against a synthetic `/proc` (a live worker's solver must survive; a process that exits mid-read is skipped).
- `uv run ruff check` — clean.
- gunicorn boots with `--config python:optimizer.gunicorn_conf` and serves `/optimize/health` 200.
- `child_exit` verified against `gunicorn/arbiter.py:559`, which is inside the reaper path that handles SIGKILLed workers.

## Not in this PR

Deploying it. The running revision still carries the accumulated orphans — `az containerapp revision restart` clears them, and the fleet should fall back to ~3-4 replicas (€233–300/month) once it does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
