### PR TITLE
infra: pin the container CBC to 2.10.10 on both architectures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,13 @@ ADD . /app
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --locked --no-editable --no-group dev
 
+# Official CBC 2.10.10 build. Fetched on the build platform, it is only unpacked here.
+FROM --platform=$BUILDPLATFORM python:3.13-slim AS cbc
+ADD --checksum=sha256:f551e7b843e25becee466a447118f6f44f219c4e46cfb4670829ecd3cf47e7d8 \
+    https://github.com/coin-or/Cbc/releases/download/releases%2F2.10.10/Cbc-releases.2.10.10-x86_64-ubuntu22-gcc1130-static.tar.gz \
+    /tmp/cbc.tar.gz
+RUN tar -xzf /tmp/cbc.tar.gz -C /usr/local ./bin/cbc
+
 FROM python:3.13-slim
 
 # Create non-root user
@@ -26,21 +33,24 @@ RUN groupadd -r app && useradd -r -g app -s /bin/false app
 # Copy the environment, but not the source code
 COPY --from=builder --chown=app:app /app/.venv /app/.venv
 
-# pulp ships CBC 2.10.3 from 2019 for amd64, Debian packages 2.10.12. pulp resolves the solver by
-# path and offers no override, so the bundled binaries become links to the packaged one.
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends coinor-cbc \
-    && rm -rf /var/lib/apt/lists/* \
-    && find /app/.venv -path '*/pulp/solverdir/cbc/*/cbc' -exec ln -sf /usr/bin/cbc {} \; \
-    && /app/.venv/bin/python -c "import pulp; \
-        s = pulp.PULP_CBC_CMD(msg=0); \
-        assert s.available(), 'cbc not executable at ' + s.pulp_cbc_path; \
+ARG TARGETARCH
+
+# pulp bundles CBC 2.10.10 for arm64 but 2.10.3 from 2019 for amd64, and resolves the solver by a
+# fixed path with no override, so the bundled amd64 binary is linked to the fetched 2.10.10 build.
+# The fetched binary is mounted rather than copied, so it does not weigh on the arm64 image.
+RUN --mount=from=cbc,source=/usr/local/bin/cbc,target=/tmp/cbc set -eu; \
+    if [ "$TARGETARCH" = "amd64" ]; then \
+        cp /tmp/cbc /usr/local/bin/cbc; \
+        find /app/.venv -path '*/pulp/solverdir/cbc/*/cbc' -exec ln -sf /usr/local/bin/cbc {} \; ; \
+    fi; \
+    solver=$(/app/.venv/bin/python -c "from pulp.apis.coin_api import pulp_cbc_path; print(pulp_cbc_path)"); \
+    echo | "$solver" | grep -q "Version: 2.10.10"; \
+    /app/.venv/bin/python -c "import pulp; \
         p = pulp.LpProblem('smoke', pulp.LpMaximize); \
         x = pulp.LpVariable('x', 0, 1, cat='Binary'); \
         p += x; \
-        p.solve(s); \
-        assert pulp.LpStatus[p.status] == 'Optimal', pulp.LpStatus[p.status]" \
-    && cbc -help 2>&1 | head -2
+        p.solve(pulp.PULP_CBC_CMD(msg=0)); \
+        assert pulp.LpStatus[p.status] == 'Optimal', pulp.LpStatus[p.status]"
 
 # Run the application
 ENV PYTHONUNBUFFERED=1

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,12 +18,9 @@ ADD . /app
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --locked --no-editable --no-group dev
 
-# Official CBC 2.10.10 build. Fetched on the build platform, it is only unpacked here.
-FROM --platform=$BUILDPLATFORM python:3.13-slim AS cbc
 ADD --checksum=sha256:f551e7b843e25becee466a447118f6f44f219c4e46cfb4670829ecd3cf47e7d8 \
     https://github.com/coin-or/Cbc/releases/download/releases%2F2.10.10/Cbc-releases.2.10.10-x86_64-ubuntu22-gcc1130-static.tar.gz \
     /tmp/cbc.tar.gz
-RUN tar -xzf /tmp/cbc.tar.gz -C /usr/local ./bin/cbc
 
 FROM python:3.13-slim
 
@@ -37,20 +34,13 @@ ARG TARGETARCH
 
 # pulp bundles CBC 2.10.10 for arm64 but 2.10.3 from 2019 for amd64, and resolves the solver by a
 # fixed path with no override, so the bundled amd64 binary is linked to the fetched 2.10.10 build.
-# The fetched binary is mounted rather than copied, so it does not weigh on the arm64 image.
-RUN --mount=from=cbc,source=/usr/local/bin/cbc,target=/tmp/cbc set -eu; \
+RUN --mount=from=builder,source=/tmp/cbc.tar.gz,target=/tmp/cbc.tar.gz set -eu; \
     if [ "$TARGETARCH" = "amd64" ]; then \
-        cp /tmp/cbc /usr/local/bin/cbc; \
+        tar -xzf /tmp/cbc.tar.gz -C /usr/local ./bin/cbc; \
         find /app/.venv -path '*/pulp/solverdir/cbc/*/cbc' -exec ln -sf /usr/local/bin/cbc {} \; ; \
     fi; \
-    solver=$(/app/.venv/bin/python -c "from pulp.apis.coin_api import pulp_cbc_path; print(pulp_cbc_path)"); \
-    echo | "$solver" | grep -q "Version: 2.10.10"; \
-    /app/.venv/bin/python -c "import pulp; \
-        p = pulp.LpProblem('smoke', pulp.LpMaximize); \
-        x = pulp.LpVariable('x', 0, 1, cat='Binary'); \
-        p += x; \
-        p.solve(pulp.PULP_CBC_CMD(msg=0)); \
-        assert pulp.LpStatus[p.status] == 'Optimal', pulp.LpStatus[p.status]"
+    echo | "$(/app/.venv/bin/python -c 'from pulp.apis.coin_api import pulp_cbc_path; print(pulp_cbc_path)')" \
+        | grep -q 'Version: 2.10.10'
 
 # Run the application
 ENV PYTHONUNBUFFERED=1

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,22 @@ RUN groupadd -r app && useradd -r -g app -s /bin/false app
 # Copy the environment, but not the source code
 COPY --from=builder --chown=app:app /app/.venv /app/.venv
 
+# pulp ships CBC 2.10.3 from 2019 for amd64, Debian packages 2.10.12. pulp resolves the solver by
+# path and offers no override, so the bundled binaries become links to the packaged one.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends coinor-cbc \
+    && rm -rf /var/lib/apt/lists/* \
+    && find /app/.venv -path '*/pulp/solverdir/cbc/*/cbc' -exec ln -sf /usr/bin/cbc {} \; \
+    && /app/.venv/bin/python -c "import pulp; \
+        s = pulp.PULP_CBC_CMD(msg=0); \
+        assert s.available(), 'cbc not executable at ' + s.pulp_cbc_path; \
+        p = pulp.LpProblem('smoke', pulp.LpMaximize); \
+        x = pulp.LpVariable('x', 0, 1, cat='Binary'); \
+        p += x; \
+        p.solve(s); \
+        assert pulp.LpStatus[p.status] == 'Optimal', pulp.LpStatus[p.status]" \
+    && cbc -help 2>&1 | head -2
+
 # Run the application
 ENV PYTHONUNBUFFERED=1
 ENV OPTIMIZER_TIME_LIMIT=10


### PR DESCRIPTION
relates to #76

The container solves with the CBC that pulp bundles, which is 2.10.10 on arm64 but 2.10.3 built in December 2019 on amd64. This puts both architectures on 2.10.10, so the deployed solver no longer depends on which image was pulled.

- fetches the official 2.10.10 static release build for amd64, checksum pinned, and links pulp's bundled binary to it. pulp resolves the solver by a fixed path and offers no override, so linking is the way in without touching application code
- leaves arm64 alone, the bundled binary there is already 2.10.10
- asserts at build time that the solver pulp resolves reports 2.10.10, so a silent fall back to the bundled binary fails the build
- image grows 5 MB on amd64, 118 to 123 MB, and stays flat on arm64
- Debian packages 2.10.12 and that was the first attempt, but it solves one of the twelve slowest captured requests to a far worse incumbent, 7.851361 against 16.364198, reproducible across runs and unchanged at a 25 s limit

The amd64 tarball is fetched on every build, including arm64 ones where it goes unused. That costs a download, not image weight.

TODO

On amd64, `013-grid-export-limit-hit` returns 17.531375 where the stored expectation is 17.537263. Both solves report a proved optimum and the same case matches exactly on arm64 at the same solver version, so this looks like a different optimum of equal real value reported through a different clean objective rather than a wrong answer. The expectations were produced against 2.10.3, and the suite keeps running against the bundled binary rather than the container, so nothing fails in CI. Worth confirming before merging.