### PR TITLE
Stop the replicas churning on a probe they cannot answer yet

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -107,7 +107,11 @@ resource containerApp 'Microsoft.App/containerApps@2025-01-01' = {
               // the config module reaps a solver that outlived its worker anyway.
               // the access log is the only source of per request latency. %(D)s is the
               // response time in microseconds, the rest of the format stays lean on purpose.
-              value: '--workers 1 --timeout 60 --max-requests 100 --max-requests-jitter 500 --config python:optimizer.gunicorn_conf --access-logfile - --access-logformat \'%(m)s %(U)s %(s)s %(D)s\''
+              // the jitter is a spread around max-requests, not a second budget: at 500 against
+              // 100 a worker recycled somewhere between 100 and 600 requests, so at roughly one
+              // request per second per replica it restarted every 2 to 10 minutes and paid a cold
+              // start each time. 50 keeps the staggering that stops replicas recycling in lockstep.
+              value: '--workers 1 --timeout 60 --max-requests 100 --max-requests-jitter 50 --config python:optimizer.gunicorn_conf --access-logfile - --access-logformat \'%(m)s %(U)s %(s)s %(D)s\''
             }
             { name: 'JWT_TOKEN_SECRET', secretRef: 'jwt-token-secret' }
           ]
@@ -119,6 +123,23 @@ resource containerApp 'Microsoft.App/containerApps@2025-01-01' = {
               }
               periodSeconds: 5
               failureThreshold: 10
+            }
+            // without an explicit readiness probe the platform polls its own from the moment the
+            // container exists, and the app is not listening yet: importing it alone takes over
+            // three seconds before gunicorn binds. That produced 419 'readiness probe failed:
+            // connection refused' warnings and 258 container starts in 24 hours, every one of them
+            // billed cold time serving nothing.
+            {
+              type: 'readiness'
+              // tcp, not http against the health route. One worker per replica means a ten second
+              // solve owns the whole process, so an http probe would time out mid solve and take
+              // a healthy replica out of rotation for doing exactly what it is there to do.
+              tcpSocket: {
+                port: 7050
+              }
+              initialDelaySeconds: 20
+              periodSeconds: 10
+              failureThreshold: 6
             }
           ]
         }


### PR DESCRIPTION
Measured over 24 h on `optimizer` in `rg-optimizer-prod`:

```
ReplicaUnhealthy   readiness probe failed: connection refused   419x
ContainerStarted                                                258x   (up to 25/hour)
```

## Readiness probe

Only a startup probe was declared, so the platform polls its own readiness probe from the moment the container exists — and the app is not listening yet. Importing it alone is 3.4 s locally, longer on a shared vCPU. Every failure round is billed cold time serving nothing.

The probe added here waits 20 s before its first poll and stays on **tcp**, deliberately not the health route: one worker per replica means a ten second solve owns the whole process, so an http probe would time out mid solve and pull a healthy replica out of rotation for doing exactly what it is there to do.

## Gunicorn jitter

`--max-requests 100 --max-requests-jitter 500`: the jitter is a spread around max-requests, not a second budget. At 500 against 100 a worker recycled somewhere between 100 and 600 requests — at roughly 1 req/s per replica, a restart every 2 to 10 minutes. 50 keeps the staggering that stops replicas recycling in lockstep, without the cold starts.

## Why this is also the cost change

Demand is flat and small: request rate 2.87–2.92 /s all day, concurrency (arrival × latency) median **1.38 cores**, max 1.58. The fleet holds 3–4 replicas at ~43% utilisation.

That gap is not a broken scale rule. The cpu rule computes and acts — `SuccessfulRescale ... reason: cpu resource above target` fires, and its scale-in decisions carry sizes (`New size: 3` 35x, `New size: 2` 15x). It parks where a 75% target says it should: a `--workers 1` replica can burn at most one core and averages ~0.46–0.50 of it, so `ceil(replicas × utilisation / target)` oscillates 2↔3, and steady state is `1.38 / 0.75 ≈ 1.8`.

Everything above that ~2 is churn — replacement replicas and the headroom they pull in. Which is what this PR removes. The `concurrentRequests: 8` http rule is inert either way: 1.38 concurrency over 3–4 replicas is ~0.4 each, an order below the threshold.

Scaling itself is untouched here on purpose. If more is wanted afterwards, raising the cpu target from 75 to ~90 gives `ceil(1.38/0.9) = 2` at the cost of burst headroom — worth measuring only once the churn numbers are in, since the two would confound each other.

`az bicep build` passes.

<sub>An earlier version of this description claimed the cpu scale rule never returned metrics and blocked scale-in. That was wrong: the `FailedGetContainerResourceMetric` events are transient, clustered in the three 30-minute windows around revision rollovers, and the sample behind the claim sat entirely inside a deploy window. The probe and jitter changes are unaffected.</sub>
