### PR TITLE
feat: add a per step forced discharge demand

### DIFF
--- a/client/client.gen.go
+++ b/client/client.gen.go
@@ -62,6 +62,13 @@ type BatteryConfig struct {
 	//   - False: (default) The battery cannot be charged while power is retrieved from grid
 	ChargeFromGrid bool `json:"charge_from_grid,omitempty"`
 
+	// DDemand Minimum discharge demand per time step (Wh). Forces the battery to discharge in the
+	// given steps, e.g. to sell into a high feed-in rate. The demand is clipped to d_max and
+	// is a soft goal: it is given up rather than draining the battery below s_min, and rather
+	// than making the request infeasible. Discharging into the grid additionally requires
+	// discharge_to_grid.
+	DDemand []float32 `json:"d_demand,omitempty"`
+
 	// DMax Maximum discharge power in W
 	DMax float32 `json:"d_max"`
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -258,6 +258,18 @@ components:
             minimum: 0
           description: Minimum charge demand per time step (Wh)
           example: [0, 1200, 1800, 2500, 1200, 1500]
+        d_demand:
+          type: array
+          items:
+            type: number
+            minimum: 0
+          description: |
+            Minimum discharge demand per time step (Wh). Forces the battery to discharge in the
+            given steps, e.g. to sell into a high feed-in rate. The demand is clipped to d_max and
+            is a soft goal: it is given up rather than draining the battery below s_min, and rather
+            than making the request infeasible. Discharging into the grid additionally requires
+            discharge_to_grid.
+          example: [0, 0, 0, 2500, 2500, 0]
         s_goal:
           type: array
           items:

--- a/src/optimizer/app.py
+++ b/src/optimizer/app.py
@@ -111,6 +111,7 @@ battery_config_model = api.model('BatteryConfig', {
     's_max': fields.Float(required=True, description='Maximum state of charge (Wh)'),
     's_initial': fields.Float(required=True, description='Initial state of charge (Wh)'),
     'p_demand': fields.List(fields.Float, required=False, description='Minimum charge demand per time step (Wh)'),
+    'd_demand': fields.List(fields.Float, required=False, description='Minimum discharge demand per time step (Wh), forces the battery to discharge.'),
     's_goal': fields.List(fields.Float, required=False, description='Goal state of charge at each time step (Wh)'),
     'c_min': fields.Float(required=True, description='Minimum charge power (W)'),
     'c_max': fields.Float(required=True, description='Maximum charge power (W)'),
@@ -201,6 +202,7 @@ class OptimizeCharging(Resource):
                     s_max=bat_data['s_max'],
                     s_initial=bat_data['s_initial'],
                     p_demand=bat_data.get('p_demand'),
+                    d_demand=bat_data.get('d_demand'),
                     s_goal=bat_data.get('s_goal'),
                     c_min=bat_data['c_min'],
                     c_max=bat_data['c_max'],
@@ -222,10 +224,11 @@ class OptimizeCharging(Resource):
             lengths = [len(time_series.gt), len(time_series.ft),
                        len(time_series.p_N), len(time_series.p_E)]
 
-            # Validate p_demand if provided
+            # Validate p_demand and d_demand if provided
             for bat in batteries:
-                if bat.p_demand is not None:
-                    lengths.append(len(bat.p_demand))
+                for series in (bat.p_demand, bat.d_demand):
+                    if series is not None:
+                        lengths.append(len(series))
 
             # Validate s_goal if provided
             for bat in batteries:

--- a/src/optimizer/optimizer.py
+++ b/src/optimizer/optimizer.py
@@ -92,6 +92,7 @@ class BatteryConfig:
     d_max: float
     p_a: float
     p_demand: Optional[List[float]] = None  # Minimum charge demand (Wh)
+    d_demand: Optional[List[float]] = None  # Minimum discharge demand, forced discharge (Wh)
     s_goal: Optional[List[float]] = None  # Goal state of charge (Wh)
     c_priority: int = 0
 
@@ -250,6 +251,13 @@ class Optimizer:
                     self.variables['z_p_demand'][i][t] = pulp.LpVariable(f"z_p_demand_{i}_{t}", cat='Binary')
                     self.variables['z_s_max_reached'][i][t] = pulp.LpVariable(f"z_s_max_reached_{i}_{t}", cat='Binary')
 
+        # penalty variable for not being able to discharge with the demanded power
+        self.variables['d_demand_pen'] = [[None for t in self.time_steps] for i in range(len(self.batteries))]
+        for i, bat in enumerate(self.batteries):
+            if bat.d_demand is not None:
+                for t in self.time_steps:
+                    self.variables['d_demand_pen'][i][t] = pulp.LpVariable(f"d_demand_pen_{i}_{t}", lowBound=0)
+
         # penalty variable for staying above max SOC and below min SOC
         self.variables['s_max_pen'] = [[pulp.LpVariable(f"s_max_pen_{i}_{t}", lowBound=0) for t in self.time_steps] for i in range(len(self.batteries))]
         self.variables['s_min_pen'] = [[pulp.LpVariable(f"s_min_pen_{i}_{t}", lowBound=0) for t in self.time_steps] for i in range(len(self.batteries))]
@@ -376,6 +384,12 @@ class Optimizer:
                     objective += - self.prc_p_goal_pen \
                         * self.variables['p_demand_pen'][i][t] \
                         * (1 + (self.T - t)/self.T)
+            # unmet discharge demand. Weighted like the charge demand and therefore an order below
+            # prc_soc_exc_pen, so a forced discharge stops at the s_min reserve instead of draining
+            # through it. No time weighting: a forced discharge names the steps it wants itself.
+            if bat.d_demand is not None:
+                for t in self.time_steps:
+                    objective += - self.prc_p_goal_pen * self.variables['d_demand_pen'][i][t]
 
         # penalties for grid power limits that cannot be met.
         for t in self.time_steps:
@@ -620,6 +634,19 @@ class Optimizer:
                                      * self.variables['z_c'][i][t])
                     self.problem += (self.variables['c'][i][t] <= bat.c_max * self.time_series.dt[t] / 3600.
                                      * self.variables['z_c'][i][t])
+
+            # Constraint: forced discharge. Soft like the charge demand above, so a demand the
+            # battery cannot serve - empty, d_max too small, needed elsewhere - is reported as an
+            # unserved remainder in the schedule rather than turning the request infeasible.
+            if bat.d_demand is not None:
+                for t in self.time_steps:
+                    if bat.d_demand[t] <= 0:
+                        continue
+
+                    # clip the demand to what the battery can deliver within the time step
+                    d_demand = min(bat.d_max * self.time_series.dt[t] / 3600., bat.d_demand[t])
+                    self.problem += (self.variables['d'][i][t]
+                                     + self.variables['d_demand_pen'][i][t] >= d_demand)
 
             # control battery charging from grid
             if not bat.charge_from_grid:

--- a/tests/test_force_discharge.py
+++ b/tests/test_force_discharge.py
@@ -1,0 +1,63 @@
+import pytest
+
+from optimizer.optimizer import BatteryConfig, GridConfig, OptimizationStrategy, Optimizer, TimeSeriesData
+
+
+def build(d_demand, discharge_to_grid=True, s_initial=10000, s_min=2000, d_max=5000, p_E=None):
+    """Four idle hours: no house load, no solar, no reason to move energy on price alone."""
+    dt = [3600] * 4
+    return Optimizer(
+        strategy=OptimizationStrategy(charging_strategy='none', discharging_strategy='none'),
+        grid=GridConfig(p_max_imp=None, p_max_exp=None, prc_p_exc_imp=None),
+        batteries=[BatteryConfig(charge_from_grid=False, discharge_to_grid=discharge_to_grid,
+                                 s_capacity=10000, s_min=s_min, s_max=10000, s_initial=s_initial,
+                                 c_min=0, c_max=5000, d_max=d_max, p_a=0.0003,
+                                 d_demand=d_demand)],
+        time_series=TimeSeriesData(dt=dt, gt=[0] * 4, ft=[0] * 4,
+                                   p_N=[0.0003] * 4, p_E=p_E or [0.0001] * 4),
+        eta_c=0.95, eta_d=0.95, M=1e6)
+
+
+def test_no_discharge_demand_leaves_the_battery_alone():
+    # baseline: p_a beats the export price, so nothing moves without a demand
+    result = build(None).solve()
+
+    assert result['status'] == 'Optimal'
+    assert result['batteries'][0]['discharging_power'] == pytest.approx([0, 0, 0, 0])
+
+
+def test_discharge_demand_forces_export_against_the_price():
+    # the same horizon, now with a demand in steps 1 and 2 - it is served even though selling at
+    # p_E is worth less than keeping the energy at p_a
+    result = build([0, 2000, 3000, 0]).solve()
+
+    assert result['status'] == 'Optimal'
+    assert result['batteries'][0]['discharging_power'] == pytest.approx([0, 2000, 3000, 0])
+    assert result['grid_export'] == pytest.approx([0, 2000, 3000, 0])
+
+
+def test_discharge_demand_is_clipped_to_d_max():
+    result = build([4000, 0, 0, 0], d_max=1000).solve()
+
+    assert result['batteries'][0]['discharging_power'][0] == pytest.approx(1000)
+
+
+def test_discharge_demand_stops_at_the_s_min_reserve():
+    # demanding more than the reserve allows must not drain through s_min: the SoC penalty
+    # outweighs the unserved demand penalty, so the remainder is simply given up
+    result = build([5000, 5000, 0, 0], s_initial=4000, s_min=2000).solve()
+
+    assert result['status'] == 'Optimal'
+    soc = result['batteries'][0]['state_of_charge']
+    assert min(soc) == pytest.approx(2000)
+    # 2000 Wh of usable content, delivered through the discharge efficiency
+    assert sum(result['batteries'][0]['discharging_power']) == pytest.approx(2000 * 0.95)
+
+
+def test_discharge_demand_is_soft_when_the_grid_is_the_only_sink():
+    # without discharge_to_grid there is nowhere for the energy to go, and the request stays
+    # solvable instead of turning infeasible
+    result = build([3000, 0, 0, 0], discharge_to_grid=False).solve()
+
+    assert result['status'] == 'Optimal'
+    assert result['batteries'][0]['discharging_power'][0] == pytest.approx(0)


### PR DESCRIPTION
Follow-up to the optimizer TODO in evcc-io/evcc#31995 ("optimizer (MIP) integration to plan export windows from price spreads — deliberately out of scope; this PR is the mode + site-logic foundation"). That PR added the `api.BatteryDischarge` mode and `batteryGridDischargeLimit`; this one gives the optimizer a way to be told about it.

## API

New optional per-battery field `d_demand`, the mirror of the existing `p_demand`:

```jsonc
"d_demand": [0, 0, 2500, 2500, 0, 0]   // discharge energy per time step (Wh)
```

Added to the flask-restx model, the request parsing, the time-series length validation, `openapi.yaml`, and the generated Go client (`go generate ./...`).

## Model

- new penalty variable `d_demand_pen[i][t]`, only for batteries that carry a demand
- constraint `d[i][t] + d_demand_pen[i][t] >= min(d_max * dt/3600, d_demand[t])`
- penalty `-prc_p_goal_pen * d_demand_pen[i][t]` in the objective, no time weighting: a forced discharge names the steps it wants itself

Deliberately soft, like the charge demand it mirrors. A demand the battery cannot serve — already empty, `d_max` too small, the energy needed by the house — leaves an unserved remainder rather than turning the request infeasible. `prc_p_goal_pen` sits an order below `prc_soc_exc_pen`, so the forced discharge stops at the `s_min` reserve instead of draining through it, which is the same reserve guard `applyBatteryMode` enforces on the evcc side.

Reaching the grid still requires `discharge_to_grid`; the demand does not override it.

## Tests

`tests/test_force_discharge.py`: no demand leaves the battery alone, a demand is served against an unfavourable price spread, clipping to `d_max`, stopping at `s_min`, and staying solvable when there is no sink for the energy. Full suite green (103 passed), ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
